### PR TITLE
Introducing HttpIncoming class

### DIFF
--- a/__tests__/http-incoming.js
+++ b/__tests__/http-incoming.js
@@ -1,0 +1,144 @@
+'use strict';
+
+const HttpIncoming = require('../lib/http-incoming');
+
+// TODO: This is silly, send PR to original-url.
+const SIMPLE_REQ = {
+    headers: {},
+};
+
+const ADVANCED_REQ = {
+    headers: {
+        host: 'localhost:3030',
+    },
+    hostname: 'localhost',
+    url: '/some/path',
+};
+
+const SIMPLE_RES = {
+    locals: {},
+};
+
+const SIMPLE_PARAMS = {
+    foo: 'bar',
+};
+
+test('PodiumHttpIncoming() - object tag - should be PodiumHttpIncoming', () => {
+    const incoming = new HttpIncoming(SIMPLE_REQ);
+    expect(Object.prototype.toString.call(incoming)).toEqual(
+        '[object PodiumHttpIncoming]',
+    );
+});
+
+test('PodiumHttpIncoming() - no arguments given - should construct object with default values', () => {
+    const incoming = new HttpIncoming(SIMPLE_REQ);
+    expect(incoming.request).toEqual(SIMPLE_REQ);
+    expect(incoming.response).toEqual({});
+    expect(incoming.url).toEqual({});
+    expect(incoming.params).toEqual({});
+    expect(incoming.context).toEqual({});
+    expect(incoming.development).toEqual(false);
+    expect(incoming.name).toEqual('');
+    expect(incoming.css).toEqual('');
+    expect(incoming.js).toEqual('');
+});
+
+test('PodiumHttpIncoming() - "request" argument given - should store request on ".request"', () => {
+    const incoming = new HttpIncoming(ADVANCED_REQ);
+    expect(incoming.request).toEqual(ADVANCED_REQ);
+});
+
+test('PodiumHttpIncoming() - "request" argument given - should set parsed URL on ".url"', () => {
+    const incoming = new HttpIncoming(ADVANCED_REQ);
+    expect(incoming.url.hostname).toEqual('localhost');
+    expect(incoming.url.host).toEqual('localhost:3030');
+    expect(incoming.url.port).toEqual('3030');
+    expect(incoming.url.protocol).toEqual('http:');
+});
+
+test('PodiumHttpIncoming() - "response" argument given - should store request on ".response"', () => {
+    const incoming = new HttpIncoming(ADVANCED_REQ, SIMPLE_RES);
+    expect(incoming.response).toEqual(SIMPLE_RES);
+});
+
+test('PodiumHttpIncoming() - "params" argument given - should store request on ".params"', () => {
+    const incoming = new HttpIncoming(ADVANCED_REQ, SIMPLE_RES, SIMPLE_PARAMS);
+    expect(incoming.params).toEqual(SIMPLE_PARAMS);
+});
+
+test('PodiumHttpIncoming.request - set value - should throw', () => {
+    expect.hasAssertions();
+    const incoming = new HttpIncoming(ADVANCED_REQ, SIMPLE_RES);
+    expect(() => {
+        incoming.request = 'foo';
+    }).toThrowError(
+        'Cannot set read-only property.',
+    );
+});
+
+test('PodiumHttpIncoming.response - set value - should throw', () => {
+    expect.hasAssertions();
+    const incoming = new HttpIncoming(ADVANCED_REQ, SIMPLE_RES);
+    expect(() => {
+        incoming.response = 'foo';
+    }).toThrowError(
+        'Cannot set read-only property.',
+    );
+});
+
+test('PodiumHttpIncoming.development - set value - should set value', () => {
+    const incoming = new HttpIncoming(ADVANCED_REQ, SIMPLE_RES);
+    incoming.development = true;
+    expect(incoming.development).toEqual(true);
+});
+
+test('PodiumHttpIncoming.name - set value - should set value', () => {
+    const incoming = new HttpIncoming(ADVANCED_REQ, SIMPLE_RES);
+    incoming.name = 'a_name';
+    expect(incoming.name).toEqual('a_name');
+});
+
+test('PodiumHttpIncoming.css - set value - should set value', () => {
+    const incoming = new HttpIncoming(ADVANCED_REQ, SIMPLE_RES);
+    incoming.css = 'a_css';
+    expect(incoming.css).toEqual('a_css');
+});
+
+test('PodiumHttpIncoming.js - set value - should set value', () => {
+    const incoming = new HttpIncoming(ADVANCED_REQ, SIMPLE_RES);
+    incoming.js = 'a_js';
+    expect(incoming.js).toEqual('a_js');
+});
+
+test('PodiumHttpIncoming.view - set value - should set value', () => {
+    const incoming = new HttpIncoming(ADVANCED_REQ, SIMPLE_RES);
+    const fn = (value) => `bar-${value}`;
+    incoming.view = fn;
+    expect(incoming.view).toEqual(fn);
+});
+
+test('PodiumHttpIncoming.render() - ".view" is not set - ".development" is "false" - should return passed in value', () => {
+    const incoming = new HttpIncoming(ADVANCED_REQ, SIMPLE_RES);
+    expect(incoming.render('foo')).toEqual('foo');
+});
+
+test('PodiumHttpIncoming.render() - ".view" is not set - ".development" is "true" - should return passed in value', () => {
+    const incoming = new HttpIncoming(ADVANCED_REQ, SIMPLE_RES);
+    incoming.development = true;
+    expect(incoming.render('foo')).toEqual('foo');
+});
+
+test('PodiumHttpIncoming.render() - ".view" is set - ".development" is "false" - should return passed in value', () => {
+    const incoming = new HttpIncoming(ADVANCED_REQ, SIMPLE_RES);
+    const fn = (value) => `bar-${value}`;
+    incoming.view = fn;
+    expect(incoming.render('foo')).toEqual('foo');
+});
+
+test('PodiumHttpIncoming.render() - ".view" is set - ".development" is "true" - should execute function set on view', () => {
+    const incoming = new HttpIncoming(ADVANCED_REQ, SIMPLE_RES);
+    const fn = (value) => `bar-${value}`;
+    incoming.view = fn;
+    incoming.development = true;
+    expect(incoming.render('foo')).toEqual('bar-foo');
+});

--- a/lib/http-incoming.js
+++ b/lib/http-incoming.js
@@ -1,0 +1,93 @@
+'use strict';
+
+const originalUrl = require('original-url');
+const { URL } = require('url');
+
+const noop = str => str;
+
+const PodiumHttpIncoming = class PodiumHttpIncoming {
+    constructor(request = {}, response = {}, params = {}) {
+        Object.defineProperty(this, 'request', {
+            enumerable: true,
+            set() {
+                throw new Error('Cannot set read-only property.');
+            },
+            get() {
+                return request;
+            },
+        });
+
+        Object.defineProperty(this, 'response', {
+            enumerable: true,
+            set() {
+                throw new Error('Cannot set read-only property.');
+            },
+            get() {
+                return response;
+            },
+        });
+
+        const url = originalUrl(request);
+        Object.defineProperty(this, 'url', {
+            enumerable: true,
+            value: url.full ? new URL(url.full) : {},
+        });
+
+        Object.defineProperty(this, 'params', {
+            enumerable: true,
+            value: params,
+        });
+
+        Object.defineProperty(this, 'context', {
+            enumerable: true,
+            value: {},
+        });
+
+        Object.defineProperty(this, 'development', {
+            enumerable: true,
+            writable: true,
+            value: false,
+        });
+
+        let view = noop;
+        Object.defineProperty(this, 'view', {
+            set(value) {
+                view = value;
+            },
+            get() {
+                return view;
+            },
+        });
+
+        Object.defineProperty(this, 'name', {
+            enumerable: true,
+            writable: true,
+            value: '',
+        });
+
+        Object.defineProperty(this, 'css', {
+            enumerable: true,
+            writable: true,
+            value: '',
+        });
+
+        Object.defineProperty(this, 'js', {
+            enumerable: true,
+            writable: true,
+            value: '',
+        });
+    }
+
+    get [Symbol.toStringTag]() {
+        return 'PodiumHttpIncoming';
+    }
+
+    render(fragment) {
+        if (this.development) {
+            return this.view(fragment, this);
+        }
+        return fragment;
+    }
+};
+
+module.exports = PodiumHttpIncoming;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,6 +2,7 @@
 
 const camelcase = require('camelcase');
 const { URL } = require('url');
+const HttpIncoming = require('./http-incoming');
 
 /**
  * Checks if a value is a string
@@ -247,3 +248,4 @@ module.exports.getFromLocalsPodium = getFromLocalsPodium;
 module.exports.duplicateOnLocalsPodium = duplicateOnLocalsPodium;
 module.exports.serializeContext = serializeContext;
 module.exports.deserializeContext = deserializeContext;
+module.exports.HttpIncoming = HttpIncoming;

--- a/package.json
+++ b/package.json
@@ -28,15 +28,6 @@
         "test:verbose": "jest --verbose",
         "test:coverage": "jest --coverage"
     },
-    "devDependencies": {
-        "eslint": "^5.6.1",
-        "eslint-config-airbnb-base": "^13.1.0",
-        "eslint-config-prettier": "^3.1.0",
-        "eslint-plugin-import": "^2.14.0",
-        "eslint-plugin-prettier": "^3.0.0",
-        "jest": "^23.6.0",
-        "prettier": "^1.14.2"
-    },
     "jest": {
         "coveragePathIgnorePatterns": [
             "test/"
@@ -51,7 +42,17 @@
         },
         "testEnvironment": "node"
     },
+    "devDependencies": {
+        "eslint": "^5.6.1",
+        "eslint-config-airbnb-base": "^13.1.0",
+        "eslint-config-prettier": "^3.1.0",
+        "eslint-plugin-import": "^2.14.0",
+        "eslint-plugin-prettier": "^3.0.0",
+        "jest": "^23.6.0",
+        "prettier": "^1.14.2"
+    },
     "dependencies": {
+        "original-url": "^1.2.1",
         "camelcase": "^5.0.0"
     }
 }


### PR DESCRIPTION
This add a common HttpIncoming class. In the process of making Podium http framework free its introduced a common object which is to be passed between the different parts in Podium on a incoming http request. It works as follow in ex a express.js middleware:

```js
const middleware = (req, res) => {
    let incoming = new HttpIncoming(req, res, res.locals);
    incoming = context.process(incoming);
    incoming = proxy.process(incoming);
}
```

This is the class for this object.

NOTE I: This module is currently not the most optimal place to place such a class. Though; I would at a later point like to rename this module to `common` and have it contain all the util methods currently in this module, the HttpIncoming class and move the schemas into it so code used by mutliple modules are in one common module.

NOTE II: The HttpIncoming class use the `original-url` module to parse the URL of a request. Currently `original-url` must have a object which has a `headers` property passed to it. Is not so, it throws a `undefined` error. Due to this, tests has a default object with a empty `headers` property. It looks a bit silly and we are not reaching 100% test coverage due to this. I will submit a PR to fix this in the `original-url` module.