### PR TITLE
Add toJSON method to HttpIncoming

### DIFF
--- a/__tests__/http-incoming.js
+++ b/__tests__/http-incoming.js
@@ -142,3 +142,17 @@ test('PodiumHttpIncoming.render() - ".view" is set - ".development" is "true" - 
     incoming.development = true;
     expect(incoming.render('foo')).toEqual('bar-foo');
 });
+
+test('PodiumHttpIncoming.toJSON() - call method - should return object without ".request" and ".resonose"', () => {
+    const incoming = new HttpIncoming(SIMPLE_REQ, SIMPLE_RES);
+    const result = incoming.toJSON();
+    expect(result.request).toEqual(undefined);
+    expect(result.response).toEqual(undefined);
+    expect(result.url).toEqual({});
+    expect(result.params).toEqual({});
+    expect(result.context).toEqual({});
+    expect(result.development).toEqual(false);
+    expect(result.name).toEqual('');
+    expect(result.css).toEqual('');
+    expect(result.js).toEqual('');
+});

--- a/lib/http-incoming.js
+++ b/lib/http-incoming.js
@@ -40,6 +40,7 @@ const PodiumHttpIncoming = class PodiumHttpIncoming {
 
         Object.defineProperty(this, 'context', {
             enumerable: true,
+            writable: true,
             value: {},
         });
 
@@ -87,6 +88,18 @@ const PodiumHttpIncoming = class PodiumHttpIncoming {
             return this.view(fragment, this);
         }
         return fragment;
+    }
+
+    toJSON() {
+        return {
+            development: this.development,
+            context: this.context,
+            params: this.params,
+            name: this.name,
+            url: this.url,
+            css: this.css,
+            js: this.js,
+        };
     }
 };
 


### PR DESCRIPTION
This appends a `toJSON()` method to the HttpIncoming constructor. This makes it possible to serialize this object without getting a circular structure which causes serializing to fail. The circular structure is caused by the values set on `.request` and `.response` and these being enumerable. That we can't change, but we do not need the values on `.request` and `.response` in the cases where this object is serialized.