### PR TITLE
Added proxy property on HttpIncoming

### DIFF
--- a/__tests__/http-incoming.js
+++ b/__tests__/http-incoming.js
@@ -36,6 +36,7 @@ test('PodiumHttpIncoming() - no arguments given - should construct object with d
     expect(incoming.response).toEqual({});
     expect(incoming.url).toEqual({});
     expect(incoming.params).toEqual({});
+    expect(incoming.proxy).toEqual(false);
     expect(incoming.context).toEqual({});
     expect(incoming.development).toEqual(false);
     expect(incoming.name).toEqual('');
@@ -86,6 +87,26 @@ test('PodiumHttpIncoming.response - set value - should throw', () => {
     );
 });
 
+test('PodiumHttpIncoming.params - set value - should throw', () => {
+    expect.hasAssertions();
+    const incoming = new HttpIncoming(ADVANCED_REQ, SIMPLE_RES);
+    expect(() => {
+        incoming.params = 'foo';
+    }).toThrowError(
+        'Cannot set read-only property.',
+    );
+});
+
+test('PodiumHttpIncoming.url - set value - should throw', () => {
+    expect.hasAssertions();
+    const incoming = new HttpIncoming(ADVANCED_REQ, SIMPLE_RES);
+    expect(() => {
+        incoming.url = 'foo';
+    }).toThrowError(
+        'Cannot set read-only property.',
+    );
+});
+
 test('PodiumHttpIncoming.development - set value - should set value', () => {
     const incoming = new HttpIncoming(ADVANCED_REQ, SIMPLE_RES);
     incoming.development = true;
@@ -108,6 +129,18 @@ test('PodiumHttpIncoming.js - set value - should set value', () => {
     const incoming = new HttpIncoming(ADVANCED_REQ, SIMPLE_RES);
     incoming.js = 'a_js';
     expect(incoming.js).toEqual('a_js');
+});
+
+test('PodiumHttpIncoming.proxy - set value - should set value', () => {
+    const incoming = new HttpIncoming(ADVANCED_REQ, SIMPLE_RES);
+    incoming.proxy = true;
+    expect(incoming.proxy).toEqual(true);
+});
+
+test('PodiumHttpIncoming.context - set value - should set value', () => {
+    const incoming = new HttpIncoming(ADVANCED_REQ, SIMPLE_RES);
+    incoming.context = { foo: 'bar' };
+    expect(incoming.context).toEqual({ foo: 'bar' });
 });
 
 test('PodiumHttpIncoming.view - set value - should set value', () => {
@@ -151,6 +184,7 @@ test('PodiumHttpIncoming.toJSON() - call method - should return object without "
     expect(result.url).toEqual({});
     expect(result.params).toEqual({});
     expect(result.context).toEqual({});
+    expect(result.proxy).toEqual(false);
     expect(result.development).toEqual(false);
     expect(result.name).toEqual('');
     expect(result.css).toEqual('');

--- a/lib/http-incoming.js
+++ b/lib/http-incoming.js
@@ -8,6 +8,7 @@ const _response = Symbol('podium:httpincoming:response');
 const _request = Symbol('podium:httpincoming:request');
 const _context = Symbol('podium:httpincoming:context');
 const _params = Symbol('podium:httpincoming:params');
+const _proxy = Symbol('podium:httpincoming:proxy');
 const _view = Symbol('podium:httpincoming:view');
 const _name = Symbol('podium:httpincoming:name');
 const _url = Symbol('podium:httpincoming:url');
@@ -26,6 +27,7 @@ const PodiumHttpIncoming = class PodiumHttpIncoming {
         this[_request] = request;
         this[_context] = {};
         this[_params] = params;
+        this[_proxy] = false;
         this[_name] = '';
         this[_view] = noop;
         this[_url] = url.full ? new URL(url.full) : {};
@@ -71,6 +73,14 @@ const PodiumHttpIncoming = class PodiumHttpIncoming {
 
     get params() {
         return this[_params];
+    }
+
+    set proxy(value) {
+        this[_proxy] = value;
+    }
+
+    get proxy() {
+        return this[_proxy];
     }
 
     set name(value) {
@@ -125,6 +135,7 @@ const PodiumHttpIncoming = class PodiumHttpIncoming {
             development: this.development,
             context: this.context,
             params: this.params,
+            proxy: this.proxy,
             name: this.name,
             url: this.url,
             css: this.css,


### PR DESCRIPTION
When a incoming request goes through the proxy `.process()` method it can eiter result in a request being proxied or not. If a request is not proxied we continue the incoming request so one can write something as a response to the request. We do this continue process by passing on the `HttpIncoming` object.

Though; if the incoming request does yeld that it should be proxied we stopp the incoming request and write the response inside the proxy `.process()` method. In this case we do currently just [resolve without passing on anything](https://github.com/podium-lib/proxy/blob/master/lib/proxy.js#L236).

This makes cheking for this in middleware a bit non intuitive since we just [check if we got a value or not](https://github.com/podium-lib/layout/blob/master/lib/layout.js#L141).

This PR ads a `proxy` property to `HttpIncoming` we can use to set to `true` / `false` to flag that the request was proxied or not. Then, in middleware we should check on this property instead of how its done today.

NB: Did also add some tests to bump test coverage.