### PR TITLE
Make default document template care about script type

### DIFF
--- a/__tests__/__snapshots__/html-document.js.snap
+++ b/__tests__/__snapshots__/html-document.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`.template() - arguments given - handles v4 js and css syntax 1`] = `
+exports[`.document() - arguments given - handles v4 js and css syntax 1`] = `
 "<!doctype html>
 <html lang=\\"en-US\\">
     <head>
@@ -10,9 +10,9 @@ exports[`.template() - arguments given - handles v4 js and css syntax 1`] = `
         <link rel=\\"stylesheet\\" type=\\"text/css\\" href=\\"http://somecssurl1.com\\">
         <link rel=\\"stylesheet\\" type=\\"text/css\\" href=\\"http://somecssurl2.com\\">
         <link rel=\\"stylesheet\\" type=\\"text/css\\" href=\\"http://somecssurl3.com\\">
-        <script src=\\"http://somejsurl1.com\\" defer></script>
-        <script src=\\"http://somejsurl2.com\\" defer></script>
-        <script src=\\"http://somejsurl3.com\\" defer></script>
+        <script defer src=\\"http://somejsurl1.com\\" ></script>
+        <script defer src=\\"http://somejsurl2.com\\" ></script>
+        <script defer src=\\"http://somejsurl3.com\\" ></script>
         <title></title>
         
     </head>
@@ -22,7 +22,7 @@ exports[`.template() - arguments given - handles v4 js and css syntax 1`] = `
 </html>"
 `;
 
-exports[`.template() - arguments given - should render template using values given 1`] = `
+exports[`.document() - arguments given - should render template using values given 1`] = `
 "<!doctype html>
 <html lang=\\"en-NZ\\">
     <head>
@@ -30,7 +30,7 @@ exports[`.template() - arguments given - should render template using values giv
         <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1\\">
         <meta http-equiv=\\"X-UA-Compatible\\" content=\\"IE=Edge\\">
         <link rel=\\"stylesheet\\" type=\\"text/css\\" href=\\"http://somecssurl.com\\">
-        <script src=\\"http://somejsurl.com\\" defer></script>
+        <script defer src=\\"http://somejsurl.com\\" ></script>
         <title>this goes in the title tag</title>
         this goes in the head section
     </head>
@@ -40,7 +40,29 @@ exports[`.template() - arguments given - should render template using values giv
 </html>"
 `;
 
-exports[`.template() - no arguments given - should render template 1`] = `
+exports[`.document() - js "type" is "module" - should set type to module on script tags 1`] = `
+"<!doctype html>
+<html lang=\\"en-US\\">
+    <head>
+        <meta charset=\\"utf-8\\">
+        <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1\\">
+        <meta http-equiv=\\"X-UA-Compatible\\" content=\\"IE=Edge\\">
+        <link rel=\\"stylesheet\\" type=\\"text/css\\" href=\\"http://somecssurl1.com\\">
+        <link rel=\\"stylesheet\\" type=\\"text/css\\" href=\\"http://somecssurl2.com\\">
+        <link rel=\\"stylesheet\\" type=\\"text/css\\" href=\\"http://somecssurl3.com\\">
+        <script type=\\"module\\" defer src=\\"http://somejsurl1.com\\"></script>
+        <script type=\\"module\\" defer src=\\"http://somejsurl2.com\\"></script>
+        <script type=\\"module\\" defer src=\\"http://somejsurl3.com\\"></script>
+        <title></title>
+        
+    </head>
+    <body>
+        
+    </body>
+</html>"
+`;
+
+exports[`.document() - no arguments given - should render template 1`] = `
 "<!doctype html>
 <html lang=\\"en-US\\">
     <head>

--- a/__tests__/html-document.js
+++ b/__tests__/html-document.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const document = require('../lib/html-document');
+
+/**
+ * .document()
+ */
+
+test('.document() - no arguments given - should render template', () => {
+    const result = document();
+    expect(result).toMatchSnapshot();
+});
+
+test('.document() - arguments given - should render template using values given', () => {
+    const result = document({
+        head: 'this goes in the head section',
+        body: 'this goes in the body section',
+        encoding: 'utf-pretend-encoding',
+        locale: 'en-NZ',
+        title: 'this goes in the title tag',
+        js: 'http://somejsurl.com',
+        css: 'http://somecssurl.com',
+    });
+    expect(result).toMatchSnapshot();
+});
+
+test('.document() - arguments given - handles v4 js and css syntax', () => {
+    const result = document({
+        js: [
+            { value: 'http://somejsurl1.com', type: 'default' },
+            { value: 'http://somejsurl2.com', type: 'default' },
+            { value: 'http://somejsurl3.com', type: 'default' },
+        ],
+        css: [
+            { value: 'http://somecssurl1.com', type: 'default' },
+            { value: 'http://somecssurl2.com', type: 'default' },
+            { value: 'http://somecssurl3.com', type: 'default' },
+        ],
+    });
+    expect(result).toMatchSnapshot();
+});
+
+test('.document() - js "type" is "module" - should set type to module on script tags', () => {
+    const result = document({
+        js: [
+            { value: 'http://somejsurl1.com', type: 'module' },
+            { value: 'http://somejsurl2.com', type: 'module' },
+            { value: 'http://somejsurl3.com', type: 'module' },
+        ],
+        css: [
+            { value: 'http://somecssurl1.com', type: 'default' },
+            { value: 'http://somecssurl2.com', type: 'default' },
+            { value: 'http://somecssurl3.com', type: 'default' },
+        ],
+    });
+    expect(result).toMatchSnapshot();
+});

--- a/__tests__/utils.js
+++ b/__tests__/utils.js
@@ -596,40 +596,4 @@ test('.deserializeContext() - prefix argument with alternate value is given - sh
     expect(result).toEqual({ foo: 'foo helium' });
 });
 
-/**
- * .template()
- */
 
-test('.template() - no arguments given - should render template', () => {
-    const result = utils.template();
-    expect(result).toMatchSnapshot();
-});
-
-test('.template() - arguments given - should render template using values given', () => {
-    const result = utils.template({
-        head: 'this goes in the head section',
-        body: 'this goes in the body section',
-        encoding: 'utf-pretend-encoding',
-        locale: 'en-NZ',
-        title: 'this goes in the title tag',
-        js: 'http://somejsurl.com',
-        css: 'http://somecssurl.com',
-    });
-    expect(result).toMatchSnapshot();
-});
-
-test('.template() - arguments given - handles v4 js and css syntax', () => {
-    const result = utils.template({
-        js: [
-            { value: 'http://somejsurl1.com', type: 'default' },
-            { value: 'http://somejsurl2.com', type: 'default' },
-            { value: 'http://somejsurl3.com', type: 'default' },
-        ],
-        css: [
-            { value: 'http://somecssurl1.com', type: 'default' },
-            { value: 'http://somecssurl2.com', type: 'default' },
-            { value: 'http://somecssurl3.com', type: 'default' },
-        ],
-    });
-    expect(result).toMatchSnapshot();
-});

--- a/lib/html-document.js
+++ b/lib/html-document.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const buildScriptTag = ({ value = '', type = 'default' }) => {
+    if (type === 'default') {
+        return `<script defer src="${value}" ></script>`;
+    }
+    return `<script type="${type}" defer src="${value}"></script>`;
+};
+
+const buildCSSLinkTag = ({ value = '', type = 'default' }) => {
+    return `<link rel="stylesheet" type="text/css" href="${value}">`;
+};
+
+const document = ({
+    head = '',
+    body = '',
+    encoding = 'utf-8',
+    locale = 'en-US',
+    title = '',
+    js = [],
+    css = [],
+} = {}) => {
+    let scripts = js;
+    let styles = css;
+
+    // backwards compatibility for scripts and styles
+    if (typeof js === 'string') scripts = [{ type: 'default', value: js }];
+    if (typeof css === 'string') styles = [{ type: 'default', value: css }];
+
+    return `<!doctype html>
+<html lang="${locale}">
+    <head>
+        <meta charset="${encoding}">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge">
+        ${styles.map(buildCSSLinkTag).join('\n        ')}
+        ${scripts.map(buildScriptTag).join('\n        ')}
+        <title>${title}</title>
+        ${head}
+    </head>
+    <body>
+        ${body}
+    </body>
+</html>`;
+};
+
+module.exports = document;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,6 +3,7 @@
 const camelcase = require('camelcase');
 const { URL } = require('url');
 const HttpIncoming = require('./http-incoming');
+const document = require('./html-document');
 
 /**
  * Checks if a value is a string
@@ -237,51 +238,6 @@ const deserializeContext = (headers = {}, prefix = 'podium') => {
     return context;
 };
 
-/**
- * Shared template function for use in layout and podlet
- *
- * @param {Object} data template argument object
- *
- * @returns {String} A merged template string
- */
-const template = ({
-    head = '',
-    body = '',
-    encoding = 'utf-8',
-    locale = 'en-US',
-    title = '',
-    js = [],
-    css = [],
-} = {}) => {
-    let scripts = js;
-    let styles = css;
-
-    const buildScriptTag = ({ value = '' }) =>
-        `<script src="${value}" defer></script>`;
-    const buildCSSLinkTag = ({ value = '' }) =>
-        `<link rel="stylesheet" type="text/css" href="${value}">`;
-
-    // backwards compatibility for scripts and styles
-    if (typeof js === 'string') scripts = [{ type: 'default', value: js }];
-    if (typeof css === 'string') styles = [{ type: 'default', value: css }];
-
-    return `<!doctype html>
-<html lang="${locale}">
-    <head>
-        <meta charset="${encoding}">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <meta http-equiv="X-UA-Compatible" content="IE=Edge">
-        ${styles.map(buildCSSLinkTag).join('\n        ')}
-        ${scripts.map(buildScriptTag).join('\n        ')}
-        <title>${title}</title>
-        ${head}
-    </head>
-    <body>
-        ${body}
-    </body>
-</html>`;
-};
-
 module.exports.isString = isString;
 module.exports.isFunction = isFunction;
 module.exports.uriBuilder = uriBuilder;
@@ -294,4 +250,4 @@ module.exports.duplicateOnLocalsPodium = duplicateOnLocalsPodium;
 module.exports.serializeContext = serializeContext;
 module.exports.deserializeContext = deserializeContext;
 module.exports.HttpIncoming = HttpIncoming;
-module.exports.template = template;
+module.exports.template = document;


### PR DESCRIPTION
Pull document template into a separate file (easier to link to to show as example) and make the printing of the script tags care about `type` being set to `module` or not.