### PR TITLE
Refactor the document template

### DIFF
--- a/__tests__/html-document.js
+++ b/__tests__/html-document.js
@@ -1,57 +1,75 @@
 'use strict';
 
+const HttpIncoming = require('../lib/http-incoming');
 const document = require('../lib/html-document');
+
+const SIMPLE_REQ = {
+    headers: {},
+};
+
+const SIMPLE_RES = {
+    locals: {},
+};
 
 /**
  * .document()
  */
 
 test('.document() - no arguments given - should render template', () => {
-    const result = document();
+    const incoming = new HttpIncoming(SIMPLE_REQ, SIMPLE_RES);
+    const result = document(incoming);
     expect(result).toMatchSnapshot();
 });
 
 test('.document() - arguments given - should render template using values given', () => {
-    const result = document({
-        head: 'this goes in the head section',
-        body: 'this goes in the body section',
-        encoding: 'utf-pretend-encoding',
+    const incoming = new HttpIncoming(SIMPLE_REQ, SIMPLE_RES);
+    incoming.css = [{ value: 'http://somecssurl.com' }];
+    incoming.js = [{ value: 'http://somejsurl.com' }];
+    incoming.context = {
         locale: 'en-NZ',
+    };
+    incoming.view = {
+        encoding: 'utf-pretend-encoding',
         title: 'this goes in the title tag',
-        js: 'http://somejsurl.com',
-        css: 'http://somecssurl.com',
-    });
+    };
+
+    const head = 'this goes in the head section';
+    const body = 'this goes in the body section';
+
+    const result = document(incoming, body, head);
     expect(result).toMatchSnapshot();
 });
 
 test('.document() - arguments given - handles v4 js and css syntax', () => {
-    const result = document({
-        js: [
-            { value: 'http://somejsurl1.com', type: 'default' },
-            { value: 'http://somejsurl2.com', type: 'default' },
-            { value: 'http://somejsurl3.com', type: 'default' },
-        ],
-        css: [
-            { value: 'http://somecssurl1.com', type: 'default' },
-            { value: 'http://somecssurl2.com', type: 'default' },
-            { value: 'http://somecssurl3.com', type: 'default' },
-        ],
-    });
+    const incoming = new HttpIncoming(SIMPLE_REQ, SIMPLE_RES);
+    incoming.css = [
+        { value: 'http://somecssurl1.com', type: 'default' },
+        { value: 'http://somecssurl2.com', type: 'default' },
+        { value: 'http://somecssurl3.com', type: 'default' },
+    ];
+    incoming.js = [
+        { value: 'http://somejsurl1.com', type: 'default' },
+        { value: 'http://somejsurl2.com', type: 'default' },
+        { value: 'http://somejsurl3.com', type: 'default' },
+    ];
+
+    const result = document(incoming);
     expect(result).toMatchSnapshot();
 });
 
 test('.document() - js "type" is "module" - should set type to module on script tags', () => {
-    const result = document({
-        js: [
-            { value: 'http://somejsurl1.com', type: 'module' },
-            { value: 'http://somejsurl2.com', type: 'module' },
-            { value: 'http://somejsurl3.com', type: 'module' },
-        ],
-        css: [
-            { value: 'http://somecssurl1.com', type: 'default' },
-            { value: 'http://somecssurl2.com', type: 'default' },
-            { value: 'http://somecssurl3.com', type: 'default' },
-        ],
-    });
+    const incoming = new HttpIncoming(SIMPLE_REQ, SIMPLE_RES);
+    incoming.css = [
+        { value: 'http://somecssurl1.com', type: 'default' },
+        { value: 'http://somecssurl2.com', type: 'default' },
+        { value: 'http://somecssurl3.com', type: 'default' },
+    ];
+    incoming.js = [
+        { value: 'http://somejsurl1.com', type: 'module' },
+        { value: 'http://somejsurl2.com', type: 'module' },
+        { value: 'http://somejsurl3.com', type: 'module' },
+    ];
+
+    const result = document(incoming);
     expect(result).toMatchSnapshot();
 });

--- a/__tests__/http-incoming.js
+++ b/__tests__/http-incoming.js
@@ -161,35 +161,19 @@ test('PodiumHttpIncoming.context - set value - should set value', () => {
     expect(incoming.context).toEqual({ foo: 'bar' });
 });
 
+test('PodiumHttpIncoming.view - no value - should return empty object', () => {
+    const incoming = new HttpIncoming(ADVANCED_REQ, SIMPLE_RES);
+    expect(incoming.view).toEqual({});
+});
+
 test('PodiumHttpIncoming.view - set value - should set value', () => {
     const incoming = new HttpIncoming(ADVANCED_REQ, SIMPLE_RES);
-    const fn = value => `bar-${value}`;
-    incoming.view = fn;
-    expect(incoming.view).toEqual(fn);
-});
-
-test('PodiumHttpIncoming.render() - ".view" is not set', () => {
-    const incoming = new HttpIncoming(ADVANCED_REQ, SIMPLE_RES);
-    expect(incoming.render({ body: 'foo' })).toEqual('foo');
-});
-
-test('PodiumHttpIncoming.render() - ".view" is not set, a string is passed to render', () => {
-    const incoming = new HttpIncoming(ADVANCED_REQ, SIMPLE_RES);
-    expect(incoming.render('foo')).toEqual('foo');
-});
-
-test('PodiumHttpIncoming.render() - ".view" is set', () => {
-    const incoming = new HttpIncoming(ADVANCED_REQ, SIMPLE_RES);
-    const fn = data => `bar-${data.body}`;
-    incoming.view = fn;
-    expect(incoming.render({ body: 'foo' })).toEqual('bar-foo');
-});
-
-test('PodiumHttpIncoming.render() - ".view" is set, a data object is passed to render', () => {
-    const incoming = new HttpIncoming(ADVANCED_REQ, SIMPLE_RES);
-    const fn = data => `bar-${data.body}`;
-    incoming.view = fn;
-    expect(incoming.render('foo')).toEqual('bar-foo');
+    incoming.view = {
+        title: 'foo'
+    };
+    expect(incoming.view).toEqual({
+        title: 'foo'
+    });
 });
 
 test('PodiumHttpIncoming.toJSON() - call method - should return object without ".request" and ".response"', () => {
@@ -200,6 +184,7 @@ test('PodiumHttpIncoming.toJSON() - call method - should return object without "
     expect(result.url).toEqual({});
     expect(result.params).toEqual({});
     expect(result.context).toEqual({});
+    expect(result.view).toEqual({});
     expect(result.proxy).toEqual(false);
     expect(result.development).toEqual(false);
     expect(result.name).toEqual('');

--- a/lib/html-document.js
+++ b/lib/html-document.js
@@ -11,31 +11,23 @@ const buildCSSLinkTag = ({ value = '', type = 'default' }) => {
     return `<link rel="stylesheet" type="text/css" href="${value}">`;
 };
 
-const document = ({
-    head = '',
-    body = '',
-    encoding = 'utf-8',
-    locale = 'en-US',
-    title = '',
-    js = [],
-    css = [],
-} = {}) => {
-    let scripts = js;
-    let styles = css;
+const document = (incoming = {}, body = '', head = '') => {
+    let scripts = incoming.js;
+    let styles = incoming.css;
 
     // backwards compatibility for scripts and styles
-    if (typeof js === 'string') scripts = [{ type: 'default', value: js }];
-    if (typeof css === 'string') styles = [{ type: 'default', value: css }];
+    if (typeof incoming.js === 'string') scripts = [{ type: 'default', value: incoming.js }];
+    if (typeof incoming.css === 'string') styles = [{ type: 'default', value: incoming.css }];
 
     return `<!doctype html>
-<html lang="${locale}">
+<html lang="${incoming.context.locale ? incoming.context.locale : 'en-US'}">
     <head>
-        <meta charset="${encoding}">
+        <meta charset="${incoming.view.encoding ? incoming.view.encoding : 'utf-8'}">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta http-equiv="X-UA-Compatible" content="IE=Edge">
         ${styles.map(buildCSSLinkTag).join('\n        ')}
         ${scripts.map(buildScriptTag).join('\n        ')}
-        <title>${title}</title>
+        <title>${incoming.view.title ? incoming.view.title : ''}</title>
         ${head}
     </head>
     <body>

--- a/lib/http-incoming.js
+++ b/lib/http-incoming.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const originalUrl = require('original-url');
-const assert = require('assert');
 const { URL } = require('url');
 
 const _development = Symbol('podium:httpincoming:development');
@@ -16,8 +15,6 @@ const _url = Symbol('podium:httpincoming:url');
 const _css = Symbol('podium:httpincoming:css');
 const _js = Symbol('podium:httpincoming:js');
 
-const noop = ({ body }) => body;
-
 const PodiumHttpIncoming = class PodiumHttpIncoming {
     constructor(request = {}, response = {}, params = {}) {
         const url = originalUrl(request);
@@ -30,7 +27,7 @@ const PodiumHttpIncoming = class PodiumHttpIncoming {
         this[_params] = params;
         this[_proxy] = false;
         this[_name] = '';
-        this[_view] = noop;
+        this[_view] = {};
         this[_url] = url.full ? new URL(url.full) : {};
         this[_css] = [];
         this[_js] = [];
@@ -130,40 +127,13 @@ const PodiumHttpIncoming = class PodiumHttpIncoming {
         return this[_js];
     }
 
-    render(data) {
-        const type = Object.prototype.toString.call(data);
-        assert(
-            type === '[object String]' || type === '[object Object]',
-            `data argument given to HttpIncoming.render must be either an object or a string`,
-        );
-
-        let ctx = data;
-        if (typeof data === 'string') {
-            ctx = { body: data };
-        }
-
-        const context = {
-            head: '',
-            body: '',
-            locale:
-                this.context && this.context.locale
-                    ? this.context.locale
-                    : 'en-US',
-            title: this.name,
-            js: this.js,
-            css: this.css,
-            ...ctx,
-        };
-
-        return this.view(context);
-    }
-
     toJSON() {
         return {
             development: this.development,
             context: this.context,
             params: this.params,
             proxy: this.proxy,
+            view: this.view,
             name: this.name,
             url: this.url,
             css: this.css,


### PR DESCRIPTION
Based on offline discussions the document template is now refactored to take `HttpIncoming` as the first argument.

This lifts the logic of doing the rendering of the document template to the `Podium` and `Layout` classes instead of something which is contian in `HttpIncoming`. There for `.render()` is now removed from `HttpIncoming`.

`.view` have also changed character from being a placeholder of the document template to being a object which can hold metadata to the document template.