### PR TITLE
Print module as script type for esm types

### DIFF
--- a/__tests__/__snapshots__/html-document.js.snap
+++ b/__tests__/__snapshots__/html-document.js.snap
@@ -40,7 +40,7 @@ exports[`.document() - arguments given - should render template using values giv
 </html>"
 `;
 
-exports[`.document() - js "type" is "module" - should set type to module on script tags 1`] = `
+exports[`.document() - js "type" is "esm" - should set type to module on script tags 1`] = `
 "<!doctype html>
 <html lang=\\"en-US\\">
     <head>
@@ -50,9 +50,9 @@ exports[`.document() - js "type" is "module" - should set type to module on scri
         <link rel=\\"stylesheet\\" type=\\"text/css\\" href=\\"http://somecssurl1.com\\">
         <link rel=\\"stylesheet\\" type=\\"text/css\\" href=\\"http://somecssurl2.com\\">
         <link rel=\\"stylesheet\\" type=\\"text/css\\" href=\\"http://somecssurl3.com\\">
-        <script type=\\"module\\" defer src=\\"http://somejsurl1.com\\"></script>
-        <script type=\\"module\\" defer src=\\"http://somejsurl2.com\\"></script>
-        <script type=\\"module\\" defer src=\\"http://somejsurl3.com\\"></script>
+        <script type=\\"module\\" defer src=\\"http://somejsurl1.com\\" ></script>
+        <script type=\\"module\\" defer src=\\"http://somejsurl2.com\\" ></script>
+        <script type=\\"module\\" defer src=\\"http://somejsurl3.com\\" ></script>
         <title></title>
         
     </head>

--- a/__tests__/html-document.js
+++ b/__tests__/html-document.js
@@ -57,7 +57,7 @@ test('.document() - arguments given - handles v4 js and css syntax', () => {
     expect(result).toMatchSnapshot();
 });
 
-test('.document() - js "type" is "module" - should set type to module on script tags', () => {
+test('.document() - js "type" is "esm" - should set type to module on script tags', () => {
     const incoming = new HttpIncoming(SIMPLE_REQ, SIMPLE_RES);
     incoming.css = [
         { value: 'http://somecssurl1.com', type: 'default' },
@@ -65,9 +65,9 @@ test('.document() - js "type" is "module" - should set type to module on script 
         { value: 'http://somecssurl3.com', type: 'default' },
     ];
     incoming.js = [
-        { value: 'http://somejsurl1.com', type: 'module' },
-        { value: 'http://somejsurl2.com', type: 'module' },
-        { value: 'http://somejsurl3.com', type: 'module' },
+        { value: 'http://somejsurl1.com', type: 'esm' },
+        { value: 'http://somejsurl2.com', type: 'esm' },
+        { value: 'http://somejsurl3.com', type: 'esm' },
     ];
 
     const result = document(incoming);

--- a/lib/html-document.js
+++ b/lib/html-document.js
@@ -1,10 +1,10 @@
 'use strict';
 
 const buildScriptTag = ({ value = '', type = 'default' }) => {
-    if (type === 'default') {
-        return `<script defer src="${value}" ></script>`;
+    if (type === 'esm') {
+        return `<script type="module" defer src="${value}" ></script>`;
     }
-    return `<script type="${type}" defer src="${value}"></script>`;
+    return `<script defer src="${value}" ></script>`;
 };
 
 const buildCSSLinkTag = ({ value = '', type = 'default' }) => {


### PR DESCRIPTION
Make the default document template print `<script type="module" ....>` when a js file is defined as `esm` in the manifest.