### PR TITLE
Add CSS and JS asset classes

### DIFF
--- a/__tests__/asset-css.js
+++ b/__tests__/asset-css.js
@@ -1,0 +1,282 @@
+'use strict';
+
+const Css = require('../lib/asset-css');
+
+test('Css() - object tag - should be PodiumAssetCss', () => {
+    const obj = new Css({ value: '/foo' });
+    expect(Object.prototype.toString.call(obj)).toEqual(
+        '[object PodiumAssetCss]',
+    );
+});
+
+test('Css() - no value given to "value" argument - should throw', () => {
+    expect.hasAssertions();
+    expect(() => {
+        const obj = new Css(); // eslint-disable-line no-unused-vars
+    }).toThrowError(
+        'Value for argument variable "value", "undefined", is not valid',
+    );
+});
+
+test('Css() - no arguments given - should construct object with default values', () => {
+    const obj = new Css({ value: '/foo' });
+    expect(obj.crossorigin).toEqual('');
+    expect(obj.disabled).toEqual(false);
+    expect(obj.hreflang).toEqual('');
+    expect(obj.value).toEqual('/foo');
+    expect(obj.title).toEqual('');
+    expect(obj.media).toEqual('');
+    expect(obj.href).toEqual('/foo');
+    expect(obj.rel).toEqual('stylesheet');
+    expect(obj.as).toEqual('');
+});
+
+test('Css() - no arguments given - should construct JSON with default values', () => {
+    const obj = new Css({ value: '/foo' });
+    const json = JSON.parse(JSON.stringify(obj));
+    expect(json).toEqual({
+        value: '/foo',
+        rel: 'stylesheet'
+    });
+});
+
+test('Css() - pathname is given - prefix is unset - should NOT append pathname to "value"', () => {
+    const obj = new Css({ value: '/foo', pathname: '/bar' });
+    expect(obj.value).toEqual('/foo');
+    expect(obj.href).toEqual('/foo');
+});
+
+test('Css() - pathname is given - prefix is false - should NOT append pathname to "value"', () => {
+    const obj = new Css({ value: '/foo', pathname: '/bar', prefix: false });
+    expect(obj.value).toEqual('/foo');
+    expect(obj.href).toEqual('/foo');
+});
+
+test('Css() - pathname is given - prefix is true - should append pathname to "value"', () => {
+    const obj = new Css({ value: '/foo', pathname: '/bar', prefix: true });
+    expect(obj.value).toEqual('/bar/foo');
+    expect(obj.href).toEqual('/bar/foo');
+});
+
+test('Css() - pathname is given - prefix is unset - should NOT append pathname to "value" for toJSON()', () => {
+    const obj = new Css({ value: '/foo', pathname: '/bar' });
+    const json = JSON.parse(JSON.stringify(obj));
+    expect(json).toEqual({
+        value: '/foo',
+        rel: 'stylesheet'
+    });
+});
+
+test('Css() - pathname is given - prefix is false - should NOT append pathname to "value" for toJSON()', () => {
+    const obj = new Css({ value: '/foo', pathname: '/bar', prefix: false });
+    const json = JSON.parse(JSON.stringify(obj));
+    expect(json).toEqual({
+        value: '/foo',
+        rel: 'stylesheet'
+    });
+});
+
+test('Css() - pathname is given - prefix is true - should NOT append pathname to "value" for toJSON()', () => {
+    const obj = new Css({ value: '/foo', pathname: '/bar', prefix: true });
+    const json = JSON.parse(JSON.stringify(obj));
+    expect(json).toEqual({
+        value: '/foo',
+        rel: 'stylesheet'
+    });
+});
+
+test('Css() - pathname is given - prefix is unset - should NOT append pathname to "href" for toHTML()', () => {
+    const obj = new Css({ value: '/foo', pathname: '/bar' });
+    expect(obj.toHTML()).toEqual('<link href="/foo" rel="stylesheet">');
+});
+
+test('Css() - pathname is given - prefix is false - should NOT append pathname to "href" for toHTML()', () => {
+    const obj = new Css({ value: '/foo', pathname: '/bar', prefix: false });
+    expect(obj.value).toEqual('/foo');
+    expect(obj.toHTML()).toEqual('<link href="/foo" rel="stylesheet">');
+});
+
+test('Css() - pathname is given - prefix is true - should append pathname to "href" for toHTML()', () => {
+    const obj = new Css({ value: '/foo', pathname: '/bar', prefix: true });
+    expect(obj.toHTML()).toEqual('<link href="/bar/foo" rel="stylesheet">');
+});
+
+test('Css() - value if absoulte - pathname is given - prefix is true - should NOT append pathname to "value"', () => {
+    const obj = new Css({ value: 'http://somewhere.else.com/foo', pathname: '/bar', prefix: true });
+    expect(obj.value).toEqual('http://somewhere.else.com/foo');
+    expect(obj.href).toEqual('http://somewhere.else.com/foo');
+
+    const json = JSON.parse(JSON.stringify(obj));
+    expect(json).toEqual({
+        value: 'http://somewhere.else.com/foo',
+        rel: 'stylesheet'
+    });
+
+    expect(obj.toHTML()).toEqual('<link href="http://somewhere.else.com/foo" rel="stylesheet">');
+});
+
+test('Css() - set "crossorigin" - should construct object as expected', () => {
+    const obj = new Css({
+        value: '/foo'
+    });
+
+    obj.crossorigin = 'bar';
+
+    expect(obj.crossorigin).toEqual('bar');
+    expect(obj.toHTML()).toEqual('<link href="/foo" crossorigin="bar" rel="stylesheet">');
+
+    const json = JSON.parse(JSON.stringify(obj));
+    expect(json).toEqual({
+        crossorigin: 'bar',
+        value: '/foo',
+        rel: 'stylesheet'
+    });
+
+    const repl = new Css(json);
+    expect(repl.crossorigin).toEqual('bar');
+});
+
+test('Css() - set "disabled" - should construct object as expected', () => {
+    const obj = new Css({
+        value: '/foo'
+    });
+
+    obj.disabled = true;
+
+    expect(obj.disabled).toEqual(true);
+    expect(obj.toHTML()).toEqual('<link href="/foo" disabled rel="stylesheet">');
+
+    const json = JSON.parse(JSON.stringify(obj));
+    expect(json).toEqual({
+        disabled: true,
+        value: '/foo',
+        rel: 'stylesheet'
+    });
+
+    const repl = new Css(json);
+    expect(repl.disabled).toEqual(true);
+});
+
+test('Css() - set "hreflang" - should construct object as expected', () => {
+    const obj = new Css({
+        value: '/foo'
+    });
+
+    obj.hreflang = 'bar';
+
+    expect(obj.hreflang).toEqual('bar');
+    expect(obj.toHTML()).toEqual('<link href="/foo" hreflang="bar" rel="stylesheet">');
+
+    const json = JSON.parse(JSON.stringify(obj));
+    expect(json).toEqual({
+        hreflang: 'bar',
+        value: '/foo',
+        rel: 'stylesheet'
+    });
+
+    const repl = new Css(json);
+    expect(repl.hreflang).toEqual('bar');
+});
+
+test('Css() - set "title" - should construct object as expected', () => {
+    const obj = new Css({
+        value: '/foo'
+    });
+
+    obj.title = 'bar';
+
+    expect(obj.title).toEqual('bar');
+    expect(obj.toHTML()).toEqual('<link href="/foo" title="bar" rel="stylesheet">');
+
+    const json = JSON.parse(JSON.stringify(obj));
+    expect(json).toEqual({
+        title: 'bar',
+        value: '/foo',
+        rel: 'stylesheet'
+    });
+
+    const repl = new Css(json);
+    expect(repl.title).toEqual('bar');
+});
+
+test('Css() - set "media" - should construct object as expected', () => {
+    const obj = new Css({
+        value: '/foo'
+    });
+
+    obj.media = 'bar';
+
+    expect(obj.media).toEqual('bar');
+    expect(obj.toHTML()).toEqual('<link href="/foo" media="bar" rel="stylesheet">');
+
+    const json = JSON.parse(JSON.stringify(obj));
+    expect(json).toEqual({
+        media: 'bar',
+        value: '/foo',
+        rel: 'stylesheet'
+    });
+
+    const repl = new Css(json);
+    expect(repl.media).toEqual('bar');
+});
+
+test('Css() - set "rel" - should construct object as expected', () => {
+    const obj = new Css({
+        value: '/foo'
+    });
+
+    obj.rel = 'bar';
+
+    expect(obj.rel).toEqual('bar');
+    expect(obj.toHTML()).toEqual('<link href="/foo" rel="bar">');
+
+    const json = JSON.parse(JSON.stringify(obj));
+    expect(json).toEqual({
+        value: '/foo',
+        rel: 'bar'
+    });
+
+    const repl = new Css(json);
+    expect(repl.rel).toEqual('bar');
+});
+
+test('Css() - set "as" - should construct object as expected', () => {
+    const obj = new Css({
+        value: '/foo'
+    });
+
+    obj.as = 'bar';
+
+    expect(obj.as).toEqual('bar');
+    expect(obj.toHTML()).toEqual('<link href="/foo" as="bar" rel="stylesheet">');
+
+    const json = JSON.parse(JSON.stringify(obj));
+    expect(json).toEqual({
+        as: 'bar',
+        value: '/foo',
+        rel: 'stylesheet'
+    });
+
+    const repl = new Css(json);
+    expect(repl.as).toEqual('bar');
+});
+
+test('Css() - set "value" - should throw', () => {
+    expect.hasAssertions();
+    const obj = new Css({
+        value: '/foo'
+    });
+    expect(() => {
+        obj.value = '/bar';
+    }).toThrowError('Cannot set read-only property.');
+});
+
+test('Css() - set "href" - should throw', () => {
+    expect.hasAssertions();
+    const obj = new Css({
+        value: '/foo'
+    });
+    expect(() => {
+        obj.href = '/bar';
+    }).toThrowError('Cannot set read-only property.');
+});

--- a/__tests__/asset-js.js
+++ b/__tests__/asset-js.js
@@ -1,0 +1,288 @@
+'use strict';
+
+const Js = require('../lib/asset-js');
+
+test('Js() - object tag - should be PodiumAssetJs', () => {
+    const obj = new Js({ value: '/foo' });
+    expect(Object.prototype.toString.call(obj)).toEqual(
+        '[object PodiumAssetJs]',
+    );
+});
+
+test('Js() - no value given to "value" argument - should throw', () => {
+    expect.hasAssertions();
+    expect(() => {
+        const obj = new Js(); // eslint-disable-line no-unused-vars
+    }).toThrowError(
+        'Value for argument variable "value", "undefined", is not valid',
+    );
+});
+
+test('Js() - no arguments given - should construct object with default values', () => {
+    const obj = new Js({ value: '/foo' });
+    expect(obj.referrerpolicy).toEqual('');
+    expect(obj.crossorigin).toEqual('');
+    expect(obj.integrity).toEqual('');
+    expect(obj.nomodule).toEqual(false);
+    expect(obj.async).toEqual(false);
+    expect(obj.defer).toEqual(false);
+    expect(obj.value).toEqual('/foo');
+    expect(obj.type).toEqual('default');
+    expect(obj.src).toEqual('/foo');
+});
+
+test('Js() - no arguments given - should construct JSON with default values', () => {
+    const obj = new Js({ value: '/foo' });
+    const json = JSON.parse(JSON.stringify(obj));
+    expect(json).toEqual({
+        value: '/foo',
+        type: 'default'
+    });
+});
+
+test('Js() - pathname is given - prefix is unset - should NOT append pathname to "value"', () => {
+    const obj = new Js({ value: '/foo', pathname: '/bar' });
+    expect(obj.value).toEqual('/foo');
+    expect(obj.src).toEqual('/foo');
+});
+
+test('Js() - pathname is given - prefix is false - should NOT append pathname to "value"', () => {
+    const obj = new Js({ value: '/foo', pathname: '/bar', prefix: false });
+    expect(obj.value).toEqual('/foo');
+    expect(obj.src).toEqual('/foo');
+});
+
+test('Js() - pathname is given - prefix is true - should append pathname to "value"', () => {
+    const obj = new Js({ value: '/foo', pathname: '/bar', prefix: true });
+    expect(obj.value).toEqual('/bar/foo');
+    expect(obj.src).toEqual('/bar/foo');
+});
+
+test('Js() - pathname is given - prefix is unset - should NOT append pathname to "value" for toJSON()', () => {
+    const obj = new Js({ value: '/foo', pathname: '/bar' });
+    const json = JSON.parse(JSON.stringify(obj));
+    expect(json).toEqual({
+        value: '/foo',
+        type: 'default'
+    });
+});
+
+test('Js() - pathname is given - prefix is false - should NOT append pathname to "value" for toJSON()', () => {
+    const obj = new Js({ value: '/foo', pathname: '/bar', prefix: false });
+    const json = JSON.parse(JSON.stringify(obj));
+    expect(json).toEqual({
+        value: '/foo',
+        type: 'default'
+    });
+});
+
+test('Js() - pathname is given - prefix is true - should NOT append pathname to "value" for toJSON()', () => {
+    const obj = new Js({ value: '/foo', pathname: '/bar', prefix: true });
+    const json = JSON.parse(JSON.stringify(obj));
+    expect(json).toEqual({
+        value: '/foo',
+        type: 'default'
+    });
+});
+
+test('Js() - pathname is given - prefix is unset - should NOT append pathname to "src" for toHTML()', () => {
+    const obj = new Js({ value: '/foo', pathname: '/bar' });
+    expect(obj.toHTML()).toEqual('<script src="/foo"></script>');
+});
+
+test('Js() - pathname is given - prefix is false - should NOT append pathname to "src" for toHTML()', () => {
+    const obj = new Js({ value: '/foo', pathname: '/bar', prefix: false });
+    expect(obj.value).toEqual('/foo');
+    expect(obj.toHTML()).toEqual('<script src="/foo"></script>');
+});
+
+test('Js() - pathname is given - prefix is true - should append pathname to "src" for toHTML()', () => {
+    const obj = new Js({ value: '/foo', pathname: '/bar', prefix: true });
+    expect(obj.toHTML()).toEqual('<script src="/bar/foo"></script>');
+});
+
+test('Js() - value if absoulte - pathname is given - prefix is true - should NOT append pathname to "value"', () => {
+    const obj = new Js({ value: 'http://somewhere.else.com/foo', pathname: '/bar', prefix: true });
+    expect(obj.value).toEqual('http://somewhere.else.com/foo');
+    expect(obj.src).toEqual('http://somewhere.else.com/foo');
+
+    const json = JSON.parse(JSON.stringify(obj));
+    expect(json).toEqual({
+        value: 'http://somewhere.else.com/foo',
+        type: 'default'
+    });
+
+    expect(obj.toHTML()).toEqual('<script src="http://somewhere.else.com/foo"></script>');
+});
+
+
+
+
+
+
+
+test('Js() - set "referrerpolicy" - should construct object as expected', () => {
+    const obj = new Js({
+        value: '/foo'
+    });
+
+    obj.referrerpolicy = 'bar';
+
+    expect(obj.referrerpolicy).toEqual('bar');
+    expect(obj.toHTML()).toEqual('<script src="/foo" referrerpolicy="bar"></script>');
+
+    const json = JSON.parse(JSON.stringify(obj));
+    expect(json).toEqual({
+        referrerpolicy: 'bar',
+        value: '/foo',
+        type: 'default'
+    });
+
+    const repl = new Js(json);
+    expect(repl.referrerpolicy).toEqual('bar');
+});
+
+test('Js() - set "crossorigin" - should construct object as expected', () => {
+    const obj = new Js({
+        value: '/foo'
+    });
+
+    obj.crossorigin = 'bar';
+
+    expect(obj.crossorigin).toEqual('bar');
+    expect(obj.toHTML()).toEqual('<script src="/foo" crossorigin="bar"></script>');
+
+    const json = JSON.parse(JSON.stringify(obj));
+    expect(json).toEqual({
+        crossorigin: 'bar',
+        value: '/foo',
+        type: 'default'
+    });
+
+    const repl = new Js(json);
+    expect(repl.crossorigin).toEqual('bar');
+});
+
+test('Js() - set "integrity" - should construct object as expected', () => {
+    const obj = new Js({
+        value: '/foo'
+    });
+
+    obj.integrity = 'bar';
+
+    expect(obj.integrity).toEqual('bar');
+    expect(obj.toHTML()).toEqual('<script src="/foo" integrity="bar"></script>');
+
+    const json = JSON.parse(JSON.stringify(obj));
+    expect(json).toEqual({
+        integrity: 'bar',
+        value: '/foo',
+        type: 'default'
+    });
+
+    const repl = new Js(json);
+    expect(repl.integrity).toEqual('bar');
+});
+
+test('Js() - set "nomodule" - should construct object as expected', () => {
+    const obj = new Js({
+        value: '/foo'
+    });
+
+    obj.nomodule = true;
+
+    expect(obj.nomodule).toEqual(true);
+    expect(obj.toHTML()).toEqual('<script src="/foo" nomodule></script>');
+
+    const json = JSON.parse(JSON.stringify(obj));
+    expect(json).toEqual({
+        nomodule: true,
+        value: '/foo',
+        type: 'default'
+    });
+
+    const repl = new Js(json);
+    expect(repl.nomodule).toEqual(true);
+});
+
+test('Js() - set "async" - should construct object as expected', () => {
+    const obj = new Js({
+        value: '/foo'
+    });
+
+    obj.async = true;
+
+    expect(obj.async).toEqual(true);
+    expect(obj.toHTML()).toEqual('<script src="/foo" async></script>');
+
+    const json = JSON.parse(JSON.stringify(obj));
+    expect(json).toEqual({
+        async: true,
+        value: '/foo',
+        type: 'default'
+    });
+
+    const repl = new Js(json);
+    expect(repl.async).toEqual(true);
+});
+
+test('Js() - set "defer" - should construct object as expected', () => {
+    const obj = new Js({
+        value: '/foo'
+    });
+
+    obj.defer = true;
+
+    expect(obj.defer).toEqual(true);
+    expect(obj.toHTML()).toEqual('<script src="/foo" defer></script>');
+
+    const json = JSON.parse(JSON.stringify(obj));
+    expect(json).toEqual({
+        defer: true,
+        value: '/foo',
+        type: 'default'
+    });
+
+    const repl = new Js(json);
+    expect(repl.defer).toEqual(true);
+});
+
+test('Js() - set "type" - should construct object as expected', () => {
+    const obj = new Js({
+        value: '/foo'
+    });
+
+    obj.type = 'esm';
+
+    expect(obj.type).toEqual('esm');
+    expect(obj.toHTML()).toEqual('<script src="/foo" type="module"></script>');
+
+    const json = JSON.parse(JSON.stringify(obj));
+    expect(json).toEqual({
+        value: '/foo',
+        type: 'esm'
+    });
+
+    const repl = new Js(json);
+    expect(repl.type).toEqual('esm');
+});
+
+test('Js() - set "value" - should throw', () => {
+    expect.hasAssertions();
+    const obj = new Js({
+        value: '/foo'
+    });
+    expect(() => {
+        obj.value = '/bar';
+    }).toThrowError('Cannot set read-only property.');
+});
+
+test('Js() - set "src" - should throw', () => {
+    expect.hasAssertions();
+    const obj = new Js({
+        value: '/foo'
+    });
+    expect(() => {
+        obj.src = '/bar';
+    }).toThrowError('Cannot set read-only property.');
+});

--- a/__tests__/http-incoming.js
+++ b/__tests__/http-incoming.js
@@ -128,7 +128,7 @@ test('PodiumHttpIncoming.css - set illegal value - should throw', () => {
     expect(() => {
         incoming.css = 'a_css';
     }).toThrowError(
-        'Value for property \".css\" must be an Array',
+        'Value for property ".css" must be an Array',
     );
 });
 
@@ -145,7 +145,7 @@ test('PodiumHttpIncoming.js - set illegal value - should throw', () => {
     expect(() => {
         incoming.js = 'a_js';
     }).toThrowError(
-        'Value for property \".js\" must be an Array',
+        'Value for property ".js" must be an Array',
     );
 });
 

--- a/lib/asset-css.js
+++ b/lib/asset-css.js
@@ -1,0 +1,189 @@
+'use strict';
+
+const { validate } = require('@podium/schemas');
+const { uriIsRelative, pathnameBuilder } = require('./utils');
+
+// Ref: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link
+// NOTE: Only includes attributes used for loading CSS
+
+const _crossorigin = Symbol('podium:asset:css:crossorigin');
+const _pathname = Symbol('podium:asset:css:pathname');
+const _disabled = Symbol('podium:asset:css:disabled');
+const _hreflang = Symbol('podium:asset:css:hreflang');
+const _prefix = Symbol('podium:asset:css:prefix');
+const _title = Symbol('podium:asset:css:title');
+const _value = Symbol('podium:asset:css:value');
+const _media = Symbol('podium:asset:css:media');
+const _rel = Symbol('podium:asset:css:rel');
+const _as = Symbol('podium:asset:css:as');
+
+const toUndefined = value => {
+    if (value === false) return undefined;
+    if (value === '') return undefined;
+    return value;
+};
+
+const notEmpty = value => {
+    if (value === false) return value;
+    if (value !== '') return true;
+    return false;
+};
+
+const PodiumAssetCss = class PodiumAssetCss {
+    constructor({
+        crossorigin = '',
+        pathname = '',
+        disabled = false,
+        hreflang = '',
+        prefix = false,
+        title = '',
+        value = undefined,
+        media = '',
+        rel = 'stylesheet',
+        as = '',
+    } = {}) {
+        if (validate.css(value).error)
+            throw new Error(
+                `Value for argument variable "value", "${value}", is not valid`,
+             );
+
+        this[_pathname] = pathname;
+        this[_prefix] = prefix;
+        this[_value] = value;
+
+        this[_crossorigin] = crossorigin;
+        this[_disabled] = disabled;
+        this[_hreflang] = hreflang;
+        this[_title] = title;
+        this[_media] = media;
+        this[_rel] = rel;
+        this[_as] = as;
+    }
+
+    get crossorigin() {
+        return this[_crossorigin];
+    }
+
+    set crossorigin(value) {
+        this[_crossorigin] = value;
+    }
+
+    get disabled() {
+        return this[_disabled];
+    }
+
+    set disabled(value) {
+        this[_disabled] = value;
+    }
+
+    get hreflang() {
+        return this[_hreflang];
+    }
+
+    set hreflang(value) {
+        this[_hreflang] = value;
+    }
+
+    get title() {
+        return this[_title];
+    }
+
+    set title(value) {
+        this[_title] = value;
+    }
+
+    get value() {
+        const pathname = this[_prefix] ? this[_pathname] : '';
+        const value = this[_value];
+        return uriIsRelative(value) ? pathnameBuilder(pathname, value) : value;
+    }
+
+    set value(value) {
+        throw new Error('Cannot set read-only property.');
+    }
+
+    get media() {
+        return this[_media];
+    }
+
+    set media(value) {
+        this[_media] = value;
+    }
+
+    get href() {
+        return this.value;
+    }
+
+    set href(value) {
+        throw new Error('Cannot set read-only property.');
+    }
+
+    get rel() {
+        return this[_rel];
+    }
+
+    set rel(value) {
+        this[_rel] = value;
+    }
+
+    get as() {
+        return this[_as];
+    }
+
+    set as(value) {
+        this[_as] = value;
+    }
+
+    toJSON() {
+        return {
+            crossorigin: toUndefined(this.crossorigin),
+            disabled: toUndefined(this.disabled),
+            hreflang: toUndefined(this.hreflang),
+            title: toUndefined(this.title),
+            value: this[_value],
+            media: toUndefined(this.media),
+            rel: this.rel,
+            as: toUndefined(this.as),
+        };
+    }
+
+    toHTML() {
+        const args = [];
+
+        args.push(`href="${this.href}"`);
+
+        if (notEmpty(this.crossorigin)) {
+            args.push(`crossorigin="${this.crossorigin}"`);
+        }
+
+        if (notEmpty(this.disabled)) {
+            args.push('disabled');
+        }
+
+        if (notEmpty(this.hreflang)) {
+            args.push(`hreflang="${this.hreflang}"`);
+        }
+
+        if (notEmpty(this.title)) {
+            args.push(`title="${this.title}"`);
+        }
+
+        if (notEmpty(this.media)) {
+            args.push(`media="${this.media}"`);
+        }
+
+        if (notEmpty(this.as)) {
+            args.push(`as="${this.as}"`);
+        }
+
+        args.push(`rel="${this.rel}"`);
+
+        return `<link ${args.join(' ')}>`;
+    }
+
+    get [Symbol.toStringTag]() {
+        return 'PodiumAssetCss';
+    }
+};
+
+module.exports = PodiumAssetCss;

--- a/lib/asset-js.js
+++ b/lib/asset-js.js
@@ -1,0 +1,191 @@
+'use strict';
+
+const { validate } = require('@podium/schemas');
+const { uriIsRelative, pathnameBuilder } = require('./utils');
+
+// Ref: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script
+// NOTE: "nonce" is deliberately left out since we do not support inline scripts
+
+const _referrerpolicy = Symbol('podium:asset:js:referrerpolicy');
+const _crossorigin = Symbol('podium:asset:js:crossorigin');
+const _integrity = Symbol('podium:asset:js:integrity');
+const _pathname = Symbol('podium:asset:js:pathname');
+const _nomodule = Symbol('podium:asset:js:nomodule');
+const _prefix = Symbol('podium:asset:js:prefix');
+const _value = Symbol('podium:asset:js:value');
+const _async = Symbol('podium:asset:js:async');
+const _defer = Symbol('podium:asset:js:defer');
+const _type = Symbol('podium:asset:js:type');
+
+const toUndefined = value => {
+    if (value === false) return undefined;
+    if (value === '') return undefined;
+    return value;
+};
+
+const notEmpty = value => {
+    if (value === false) return value;
+    if (value !== '') return true;
+    return false;
+};
+
+const PodiumAssetJs = class PodiumAssetJs {
+    constructor({
+        referrerpolicy = '',
+        crossorigin = '',
+        integrity = '',
+        pathname = '',
+        nomodule = false,
+        prefix = false,
+        value = undefined,
+        async = false,
+        defer = false,
+        type = 'default',
+    } = {}) {
+        if (validate.js(value).error)
+            throw new Error(
+                `Value for argument variable "value", "${value}", is not valid`,
+            );
+
+        this[_pathname] = pathname;
+        this[_prefix] = prefix;
+        this[_value] = value;
+
+        this[_referrerpolicy] = referrerpolicy;
+        this[_crossorigin] = crossorigin;
+        this[_integrity] = integrity;
+        this[_nomodule] = nomodule;
+        this[_async] = async;
+        this[_defer] = defer;
+        this[_type] = type;
+    }
+
+    get referrerpolicy() {
+        return this[_referrerpolicy];
+    }
+
+    set referrerpolicy(value) {
+        this[_referrerpolicy] = value;
+    }
+
+    get crossorigin() {
+        return this[_crossorigin];
+    }
+
+    set crossorigin(value) {
+        this[_crossorigin] = value;
+    }
+
+    get integrity() {
+        return this[_integrity];
+    }
+
+    set integrity(value) {
+        this[_integrity] = value;
+    }
+
+    get nomodule() {
+        return this[_nomodule];
+    }
+
+    set nomodule(value) {
+        this[_nomodule] = value;
+    }
+
+    get value() {
+        const pathname = this[_prefix] ? this[_pathname] : '';
+        const value = this[_value];
+        return uriIsRelative(value) ? pathnameBuilder(pathname, value) : value;
+    }
+
+    set value(value) {
+        throw new Error('Cannot set read-only property.');
+    }
+
+    get async() {
+        return this[_async];
+    }
+
+    set async(value) {
+        this[_async] = value;
+    }
+
+    get defer() {
+        return this[_defer];
+    }
+
+    set defer(value) {
+        this[_defer] = value;
+    }
+
+    get type() {
+        return this[_type];
+    }
+
+    set type(value) {
+        this[_type] = value;
+    }
+
+    get src() {
+        return this.value;
+    }
+
+    set src(value) {
+        throw new Error('Cannot set read-only property.');
+    }
+
+    toJSON() {
+        return {
+            referrerpolicy: toUndefined(this.referrerpolicy),
+            crossorigin: toUndefined(this.crossorigin),
+            integrity: toUndefined(this.integrity),
+            nomodule: toUndefined(this.nomodule),
+            value: this[_value],
+            async: toUndefined(this.async),
+            defer: toUndefined(this.defer),
+            type: this.type,
+        };
+    }
+
+    toHTML() {
+        const args = [];
+
+        args.push(`src="${this.src}"`);
+
+        if (this.type === 'esm' || this.type === 'module') {
+            args.push('type="module"');
+        }
+
+        if (notEmpty(this.referrerpolicy)) {
+            args.push(`referrerpolicy="${this.referrerpolicy}"`);
+        }
+
+        if (notEmpty(this.crossorigin)) {
+            args.push(`crossorigin="${this.crossorigin}"`);
+        }
+
+        if (notEmpty(this.integrity)) {
+            args.push(`integrity="${this.integrity}"`);
+        }
+
+        if (notEmpty(this.nomodule)) {
+            args.push('nomodule');
+        }
+
+        if (notEmpty(this.async)) {
+            args.push('async');
+        }
+
+        if (notEmpty(this.defer)) {
+            args.push('defer');
+        }
+
+        return `<script ${args.join(' ')}></script>`;
+    }
+
+    get [Symbol.toStringTag]() {
+        return 'PodiumAssetJs';
+    }
+};
+
+module.exports = PodiumAssetJs;

--- a/lib/html-document.js
+++ b/lib/html-document.js
@@ -7,7 +7,7 @@ const buildScriptTag = ({ value = '', type = 'default' }) => {
     return `<script defer src="${value}" ></script>`;
 };
 
-const buildCSSLinkTag = ({ value = '', type = 'default' }) => {
+const buildCSSLinkTag = ({ value = '' }) => {
     return `<link rel="stylesheet" type="text/css" href="${value}">`;
 };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,6 +4,8 @@ const camelcase = require('camelcase');
 const { URL } = require('url');
 const HttpIncoming = require('./http-incoming');
 const document = require('./html-document');
+const AssetCss = require('./asset-css');
+const AssetJs = require('./asset-js');
 
 /**
  * Checks if a value is a string
@@ -251,3 +253,5 @@ module.exports.serializeContext = serializeContext;
 module.exports.deserializeContext = deserializeContext;
 module.exports.HttpIncoming = HttpIncoming;
 module.exports.template = document;
+module.exports.AssetCss = AssetCss;
+module.exports.AssetJs = AssetJs;

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
         "prettier": "^1.16.4"
     },
     "dependencies": {
+        "@podium/schemas": "4.0.0",
         "camelcase": "^5.3.0",
         "original-url": "^1.2.1"
     }


### PR DESCRIPTION
This adds a CSS and JS class which reflects the different attributes the respective `<script>` and `<link>` tags can have to load each type of asset. 

The intention of these classes are for internal use when one set CSS or JS assets through the `.css()` and `.js()` methods in @podium/podlet or @podium/layout. These classes makes it easier for us to exchange info about assets between a podlet and a layout making sure that when one use an property on the asset objects (ex in the document template) the property will always be present mo matter what the manifest contained in the exchange between a podlet and a layout.

These classes also simplifies the process of maintaining when `pathname` should be added and not to the `value` in both @podium/podlet or @podium/layout.