### PR TITLE
Prevent circular dependencies

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const HttpIncoming = require('./http-incoming');
+const document = require('./html-document');
+const AssetCss = require('./asset-css');
+const AssetJs = require('./asset-js');
+const utils = require('./utils');
+
+module.exports.isString = utils.isString;
+module.exports.isFunction = utils.isFunction;
+module.exports.uriBuilder = utils.uriBuilder;
+module.exports.uriIsRelative = utils.uriIsRelative;
+module.exports.pathnameBuilder = utils.pathnameBuilder;
+module.exports.uriRelativeToAbsolute = utils.uriRelativeToAbsolute;
+module.exports.setAtLocalsPodium = utils.setAtLocalsPodium;
+module.exports.getFromLocalsPodium = utils.getFromLocalsPodium;
+module.exports.duplicateOnLocalsPodium = utils.duplicateOnLocalsPodium;
+module.exports.serializeContext = utils.serializeContext;
+module.exports.deserializeContext = utils.deserializeContext;
+module.exports.HttpIncoming = HttpIncoming;
+module.exports.template = document;
+module.exports.AssetCss = AssetCss;
+module.exports.AssetJs = AssetJs;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,10 +2,6 @@
 
 const camelcase = require('camelcase');
 const { URL } = require('url');
-const HttpIncoming = require('./http-incoming');
-const document = require('./html-document');
-const AssetCss = require('./asset-css');
-const AssetJs = require('./asset-js');
 
 /**
  * Checks if a value is a string
@@ -251,7 +247,3 @@ module.exports.getFromLocalsPodium = getFromLocalsPodium;
 module.exports.duplicateOnLocalsPodium = duplicateOnLocalsPodium;
 module.exports.serializeContext = serializeContext;
 module.exports.deserializeContext = deserializeContext;
-module.exports.HttpIncoming = HttpIncoming;
-module.exports.template = document;
-module.exports.AssetCss = AssetCss;
-module.exports.AssetJs = AssetJs;

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "files": [
         "lib"
     ],
-    "main": "./lib/utils.js",
+    "main": "./lib/main.js",
     "scripts": {
         "lint": "eslint .",
         "lint:fix": "eslint --fix .",


### PR DESCRIPTION
That `asset-css` and `asset-js` is exported in `utils` while being imported in `utils` created a circular dependency when this module is depended on. Prevent this.