### PR TITLE
add typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,55 @@
+import { IncomingMessage, ServerResponse } from 'http';
+
+declare interface PodiumAsset {
+    readonly value: string;
+    prefix?: boolean;
+    toHTML(): string;
+}
+
+export interface AssetCss extends PodiumAsset {
+    as?: Pick<HTMLLinkElement, 'as'>;
+    crossorigin?: Pick<HTMLLinkElement, 'crossOrigin'>;
+    disabled?: Pick<HTMLLinkElement, 'disabled'>;
+    hreflang?: Pick<HTMLLinkElement, 'hreflang'>;
+    title?: Pick<HTMLLinkElement, 'title'>;
+    media?: Pick<HTMLLinkElement, 'media'>;
+    rel?: Pick<HTMLLinkElement, 'rel'>;
+}
+
+export interface AssetJs extends PodiumAsset {
+    referrerpolicy?: Pick<HTMLScriptElement, 'referrerPolicy'>;
+    crossorigin?: Pick<HTMLScriptElement, 'crossOrigin'>;
+    integrity?: Pick<HTMLScriptElement, 'integrity'>;
+    nomodule?: Pick<HTMLScriptElement, 'noModule'>;
+    async?: Pick<HTMLScriptElement, 'async'>;
+    defer?: Pick<HTMLScriptElement, 'defer'>;
+    type?: Pick<HTMLScriptElement, 'type'>;
+}
+
+export class HttpIncoming<T = { [key: string]: unknown }> {
+    constructor(request: IncomingMessage, response: ServerResponse, params: T);
+
+    development: boolean;
+
+    readonly response: ServerResponse;
+
+    readonly request: IncomingMessage;
+
+    context: any;
+
+    readonly params: T;
+
+    proxy: boolean;
+
+    name: string;
+
+    view: any;
+
+    readonly url: URL;
+
+    css: Array<AssetCss>;
+
+    js: Array<AssetJs>;
+
+    toJSON(): { development: boolean, context: any, params: T, proxy: boolean, name: string; url: URL, css: Array<AssetCss>, js: Array<AssetJs> };
+}

--- a/package.json
+++ b/package.json
@@ -18,9 +18,11 @@
     },
     "homepage": "https://podium-lib.io/",
     "files": [
-        "lib"
+        "lib",
+        "index.d.ts"
     ],
     "main": "./lib/main.js",
+    "types": "index.d.ts",
     "scripts": {
         "lint": "eslint .",
         "lint:fix": "eslint --fix .",


### PR DESCRIPTION
This pull request adds a TypeScript definition file. I've only typed the stuff in use by the surface API of the other Podium modules, so I haven't typed the utility methods this package exposes.

I've typed `view` and `context` as `any` for now. Imo it is an okay compromise to get types out of the door to be improved upon later.

