### PR TITLE
Add type to CSS class

### DIFF
--- a/__tests__/asset-css.js
+++ b/__tests__/asset-css.js
@@ -26,6 +26,7 @@ test('Css() - no arguments given - should construct object with default values',
     expect(obj.value).toEqual('/foo');
     expect(obj.title).toEqual('');
     expect(obj.media).toEqual('');
+    expect(obj.type).toEqual('text/css');
     expect(obj.href).toEqual('/foo');
     expect(obj.rel).toEqual('stylesheet');
     expect(obj.as).toEqual('');
@@ -36,6 +37,7 @@ test('Css() - no arguments given - should construct JSON with default values', (
     const json = JSON.parse(JSON.stringify(obj));
     expect(json).toEqual({
         value: '/foo',
+        type: 'text/css',
         rel: 'stylesheet'
     });
 });
@@ -63,6 +65,7 @@ test('Css() - pathname is given - prefix is unset - should NOT append pathname t
     const json = JSON.parse(JSON.stringify(obj));
     expect(json).toEqual({
         value: '/foo',
+        type: 'text/css',
         rel: 'stylesheet'
     });
 });
@@ -72,6 +75,7 @@ test('Css() - pathname is given - prefix is false - should NOT append pathname t
     const json = JSON.parse(JSON.stringify(obj));
     expect(json).toEqual({
         value: '/foo',
+        type: 'text/css',
         rel: 'stylesheet'
     });
 });
@@ -81,24 +85,25 @@ test('Css() - pathname is given - prefix is true - should NOT append pathname to
     const json = JSON.parse(JSON.stringify(obj));
     expect(json).toEqual({
         value: '/foo',
+        type: 'text/css',
         rel: 'stylesheet'
     });
 });
 
 test('Css() - pathname is given - prefix is unset - should NOT append pathname to "href" for toHTML()', () => {
     const obj = new Css({ value: '/foo', pathname: '/bar' });
-    expect(obj.toHTML()).toEqual('<link href="/foo" rel="stylesheet">');
+    expect(obj.toHTML()).toEqual('<link href="/foo" type="text/css" rel="stylesheet">');
 });
 
 test('Css() - pathname is given - prefix is false - should NOT append pathname to "href" for toHTML()', () => {
     const obj = new Css({ value: '/foo', pathname: '/bar', prefix: false });
     expect(obj.value).toEqual('/foo');
-    expect(obj.toHTML()).toEqual('<link href="/foo" rel="stylesheet">');
+    expect(obj.toHTML()).toEqual('<link href="/foo" type="text/css" rel="stylesheet">');
 });
 
 test('Css() - pathname is given - prefix is true - should append pathname to "href" for toHTML()', () => {
     const obj = new Css({ value: '/foo', pathname: '/bar', prefix: true });
-    expect(obj.toHTML()).toEqual('<link href="/bar/foo" rel="stylesheet">');
+    expect(obj.toHTML()).toEqual('<link href="/bar/foo" type="text/css" rel="stylesheet">');
 });
 
 test('Css() - value if absoulte - pathname is given - prefix is true - should NOT append pathname to "value"', () => {
@@ -109,10 +114,11 @@ test('Css() - value if absoulte - pathname is given - prefix is true - should NO
     const json = JSON.parse(JSON.stringify(obj));
     expect(json).toEqual({
         value: 'http://somewhere.else.com/foo',
+        type: 'text/css',
         rel: 'stylesheet'
     });
 
-    expect(obj.toHTML()).toEqual('<link href="http://somewhere.else.com/foo" rel="stylesheet">');
+    expect(obj.toHTML()).toEqual('<link href="http://somewhere.else.com/foo" type="text/css" rel="stylesheet">');
 });
 
 test('Css() - set "crossorigin" - should construct object as expected', () => {
@@ -123,12 +129,13 @@ test('Css() - set "crossorigin" - should construct object as expected', () => {
     obj.crossorigin = 'bar';
 
     expect(obj.crossorigin).toEqual('bar');
-    expect(obj.toHTML()).toEqual('<link href="/foo" crossorigin="bar" rel="stylesheet">');
+    expect(obj.toHTML()).toEqual('<link href="/foo" crossorigin="bar" type="text/css" rel="stylesheet">');
 
     const json = JSON.parse(JSON.stringify(obj));
     expect(json).toEqual({
         crossorigin: 'bar',
         value: '/foo',
+        type: 'text/css',
         rel: 'stylesheet'
     });
 
@@ -144,12 +151,13 @@ test('Css() - set "disabled" - should construct object as expected', () => {
     obj.disabled = true;
 
     expect(obj.disabled).toEqual(true);
-    expect(obj.toHTML()).toEqual('<link href="/foo" disabled rel="stylesheet">');
+    expect(obj.toHTML()).toEqual('<link href="/foo" disabled type="text/css" rel="stylesheet">');
 
     const json = JSON.parse(JSON.stringify(obj));
     expect(json).toEqual({
         disabled: true,
         value: '/foo',
+        type: 'text/css',
         rel: 'stylesheet'
     });
 
@@ -165,12 +173,13 @@ test('Css() - set "hreflang" - should construct object as expected', () => {
     obj.hreflang = 'bar';
 
     expect(obj.hreflang).toEqual('bar');
-    expect(obj.toHTML()).toEqual('<link href="/foo" hreflang="bar" rel="stylesheet">');
+    expect(obj.toHTML()).toEqual('<link href="/foo" hreflang="bar" type="text/css" rel="stylesheet">');
 
     const json = JSON.parse(JSON.stringify(obj));
     expect(json).toEqual({
         hreflang: 'bar',
         value: '/foo',
+        type: 'text/css',
         rel: 'stylesheet'
     });
 
@@ -186,12 +195,13 @@ test('Css() - set "title" - should construct object as expected', () => {
     obj.title = 'bar';
 
     expect(obj.title).toEqual('bar');
-    expect(obj.toHTML()).toEqual('<link href="/foo" title="bar" rel="stylesheet">');
+    expect(obj.toHTML()).toEqual('<link href="/foo" title="bar" type="text/css" rel="stylesheet">');
 
     const json = JSON.parse(JSON.stringify(obj));
     expect(json).toEqual({
         title: 'bar',
         value: '/foo',
+        type: 'text/css',
         rel: 'stylesheet'
     });
 
@@ -207,17 +217,39 @@ test('Css() - set "media" - should construct object as expected', () => {
     obj.media = 'bar';
 
     expect(obj.media).toEqual('bar');
-    expect(obj.toHTML()).toEqual('<link href="/foo" media="bar" rel="stylesheet">');
+    expect(obj.toHTML()).toEqual('<link href="/foo" media="bar" type="text/css" rel="stylesheet">');
 
     const json = JSON.parse(JSON.stringify(obj));
     expect(json).toEqual({
         media: 'bar',
         value: '/foo',
+        type: 'text/css',
         rel: 'stylesheet'
     });
 
     const repl = new Css(json);
     expect(repl.media).toEqual('bar');
+});
+
+test('Css() - set "type" - should construct object as expected', () => {
+    const obj = new Css({
+        value: '/foo'
+    });
+
+    obj.type = 'bar';
+
+    expect(obj.type).toEqual('bar');
+    expect(obj.toHTML()).toEqual('<link href="/foo" type="bar" rel="stylesheet">');
+
+    const json = JSON.parse(JSON.stringify(obj));
+    expect(json).toEqual({
+        value: '/foo',
+        type: 'bar',
+        rel: 'stylesheet'
+    });
+
+    const repl = new Css(json);
+    expect(repl.type).toEqual('bar');
 });
 
 test('Css() - set "rel" - should construct object as expected', () => {
@@ -228,11 +260,12 @@ test('Css() - set "rel" - should construct object as expected', () => {
     obj.rel = 'bar';
 
     expect(obj.rel).toEqual('bar');
-    expect(obj.toHTML()).toEqual('<link href="/foo" rel="bar">');
+    expect(obj.toHTML()).toEqual('<link href="/foo" type="text/css" rel="bar">');
 
     const json = JSON.parse(JSON.stringify(obj));
     expect(json).toEqual({
         value: '/foo',
+        type: 'text/css',
         rel: 'bar'
     });
 
@@ -248,12 +281,13 @@ test('Css() - set "as" - should construct object as expected', () => {
     obj.as = 'bar';
 
     expect(obj.as).toEqual('bar');
-    expect(obj.toHTML()).toEqual('<link href="/foo" as="bar" rel="stylesheet">');
+    expect(obj.toHTML()).toEqual('<link href="/foo" as="bar" type="text/css" rel="stylesheet">');
 
     const json = JSON.parse(JSON.stringify(obj));
     expect(json).toEqual({
         as: 'bar',
         value: '/foo',
+        type: 'text/css',
         rel: 'stylesheet'
     });
 

--- a/lib/asset-css.js
+++ b/lib/asset-css.js
@@ -14,6 +14,7 @@ const _prefix = Symbol('podium:asset:css:prefix');
 const _title = Symbol('podium:asset:css:title');
 const _value = Symbol('podium:asset:css:value');
 const _media = Symbol('podium:asset:css:media');
+const _type = Symbol('podium:asset:css:type');
 const _rel = Symbol('podium:asset:css:rel');
 const _as = Symbol('podium:asset:css:as');
 
@@ -39,6 +40,7 @@ const PodiumAssetCss = class PodiumAssetCss {
         title = '',
         value = undefined,
         media = '',
+        type = 'text/css',
         rel = 'stylesheet',
         as = '',
     } = {}) {
@@ -56,6 +58,7 @@ const PodiumAssetCss = class PodiumAssetCss {
         this[_hreflang] = hreflang;
         this[_title] = title;
         this[_media] = media;
+        this[_type] = type;
         this[_rel] = rel;
         this[_as] = as;
     }
@@ -110,6 +113,14 @@ const PodiumAssetCss = class PodiumAssetCss {
         this[_media] = value;
     }
 
+    get type() {
+        return this[_type];
+    }
+
+    set type(value) {
+        this[_type] = value;
+    }
+
     get href() {
         return this.value;
     }
@@ -142,6 +153,7 @@ const PodiumAssetCss = class PodiumAssetCss {
             title: toUndefined(this.title),
             value: this[_value],
             media: toUndefined(this.media),
+            type: this.type,
             rel: this.rel,
             as: toUndefined(this.as),
         };
@@ -176,6 +188,7 @@ const PodiumAssetCss = class PodiumAssetCss {
             args.push(`as="${this.as}"`);
         }
 
+        args.push(`type="${this.type}"`);
         args.push(`rel="${this.rel}"`);
 
         return `<link ${args.join(' ')}>`;


### PR DESCRIPTION
Turns out `type` for CSS is needed after all so adding type as a property to the CSS class.