### PR TITLE
Html utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ The method takes the following arguments:
 -   assetCss - `Object` - A CSS Asset object
 
 ```js
-const utils = require(@podium/utils);
+const utils = require('@podium/utils');
 
 const css = new utils.AssetCss({
     value: 'https://cdn.foo.com/style.css'
@@ -267,7 +267,7 @@ The method takes the following arguments:
 -   assetJs - `Object` - A JS Asset object
 
 ```js
-const utils = require(@podium/utils);
+const utils = require('@podium/utils');
 
 const js = new utils.AssetJs({
     value: 'https://cdn.foo.com/script.js'

--- a/README.md
+++ b/README.md
@@ -236,3 +236,45 @@ This method takes a single argument:
 -   `data.js` - JavaScript URL, will be used as a `src` value in a script tag
 -   `data.css` - CSS URL, will be used as an `href` value in a link tag
 -   `data.body` - HTML body markup to be rendered
+
+### .buildLinkElement(assetCss)
+
+Build a HTML link element out of a AssetCss object.
+
+The method takes the following arguments:
+
+-   assetCss - `Object` - A CSS Asset object
+
+```js
+const utils = require(@podium/utils);
+
+const css = new utils.AssetCss({
+    value: 'https://cdn.foo.com/style.css'
+});
+
+const element = utils.buildLinkElement(css);
+// element is: <link href="" .....
+```
+
+returns A HTML link element as a String.
+
+### .buildScriptElement(assetJs)
+
+Build a HTML script element out of a AssetJs object.
+
+The method takes the following arguments:
+
+-   assetJs - `Object` - A JS Asset object
+
+```js
+const utils = require(@podium/utils);
+
+const js = new utils.AssetJs({
+    value: 'https://cdn.foo.com/script.js'
+});
+
+const element = utils.buildLinkElement(js);
+// element is: <script src="" .....
+```
+
+returns A HTML script element as a String.

--- a/__tests__/__snapshots__/html-document.js.snap
+++ b/__tests__/__snapshots__/html-document.js.snap
@@ -7,12 +7,12 @@ exports[`.document() - arguments given - handles v4 js and css syntax 1`] = `
         <meta charset=\\"utf-8\\">
         <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1\\">
         <meta http-equiv=\\"X-UA-Compatible\\" content=\\"IE=Edge\\">
-        <link rel=\\"stylesheet\\" type=\\"text/css\\" href=\\"http://somecssurl1.com\\">
-        <link rel=\\"stylesheet\\" type=\\"text/css\\" href=\\"http://somecssurl2.com\\">
-        <link rel=\\"stylesheet\\" type=\\"text/css\\" href=\\"http://somecssurl3.com\\">
-        <script defer src=\\"http://somejsurl1.com\\" ></script>
-        <script defer src=\\"http://somejsurl2.com\\" ></script>
-        <script defer src=\\"http://somejsurl3.com\\" ></script>
+        <link href=\\"http://somecssurl1.com\\" type=\\"text/css\\">
+        <link href=\\"http://somecssurl2.com\\" type=\\"text/css\\">
+        <link href=\\"http://somecssurl3.com\\" type=\\"text/css\\">
+        <script src=\\"http://somejsurl1.com\\"></script>
+        <script src=\\"http://somejsurl2.com\\"></script>
+        <script src=\\"http://somejsurl3.com\\"></script>
         <title></title>
         
     </head>
@@ -29,8 +29,8 @@ exports[`.document() - arguments given - should render template using values giv
         <meta charset=\\"utf-pretend-encoding\\">
         <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1\\">
         <meta http-equiv=\\"X-UA-Compatible\\" content=\\"IE=Edge\\">
-        <link rel=\\"stylesheet\\" type=\\"text/css\\" href=\\"http://somecssurl.com\\">
-        <script defer src=\\"http://somejsurl.com\\" ></script>
+        <link href=\\"http://somecssurl.com\\">
+        <script src=\\"http://somejsurl.com\\"></script>
         <title>this goes in the title tag</title>
         this goes in the head section
     </head>
@@ -47,12 +47,12 @@ exports[`.document() - js "type" is "esm" - should set type to module on script 
         <meta charset=\\"utf-8\\">
         <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1\\">
         <meta http-equiv=\\"X-UA-Compatible\\" content=\\"IE=Edge\\">
-        <link rel=\\"stylesheet\\" type=\\"text/css\\" href=\\"http://somecssurl1.com\\">
-        <link rel=\\"stylesheet\\" type=\\"text/css\\" href=\\"http://somecssurl2.com\\">
-        <link rel=\\"stylesheet\\" type=\\"text/css\\" href=\\"http://somecssurl3.com\\">
-        <script type=\\"module\\" defer src=\\"http://somejsurl1.com\\" ></script>
-        <script type=\\"module\\" defer src=\\"http://somejsurl2.com\\" ></script>
-        <script type=\\"module\\" defer src=\\"http://somejsurl3.com\\" ></script>
+        <link href=\\"http://somecssurl1.com\\" type=\\"text/css\\">
+        <link href=\\"http://somecssurl2.com\\" type=\\"text/css\\">
+        <link href=\\"http://somecssurl3.com\\" type=\\"text/css\\">
+        <script src=\\"http://somejsurl1.com\\" type=\\"module\\"></script>
+        <script src=\\"http://somejsurl2.com\\" type=\\"module\\"></script>
+        <script src=\\"http://somejsurl3.com\\" type=\\"module\\"></script>
         <title></title>
         
     </head>

--- a/__tests__/html-document.js
+++ b/__tests__/html-document.js
@@ -43,9 +43,9 @@ test('.document() - arguments given - should render template using values given'
 test('.document() - arguments given - handles v4 js and css syntax', () => {
     const incoming = new HttpIncoming(SIMPLE_REQ, SIMPLE_RES);
     incoming.css = [
-        { value: 'http://somecssurl1.com', type: 'default' },
-        { value: 'http://somecssurl2.com', type: 'default' },
-        { value: 'http://somecssurl3.com', type: 'default' },
+        { value: 'http://somecssurl1.com', type: 'text/css' },
+        { value: 'http://somecssurl2.com', type: 'text/css' },
+        { value: 'http://somecssurl3.com', type: 'text/css' },
     ];
     incoming.js = [
         { value: 'http://somejsurl1.com', type: 'default' },
@@ -60,9 +60,9 @@ test('.document() - arguments given - handles v4 js and css syntax', () => {
 test('.document() - js "type" is "esm" - should set type to module on script tags', () => {
     const incoming = new HttpIncoming(SIMPLE_REQ, SIMPLE_RES);
     incoming.css = [
-        { value: 'http://somecssurl1.com', type: 'default' },
-        { value: 'http://somecssurl2.com', type: 'default' },
-        { value: 'http://somecssurl3.com', type: 'default' },
+        { value: 'http://somecssurl1.com', type: 'text/css' },
+        { value: 'http://somecssurl2.com', type: 'text/css' },
+        { value: 'http://somecssurl3.com', type: 'text/css' },
     ];
     incoming.js = [
         { value: 'http://somejsurl1.com', type: 'esm' },

--- a/__tests__/html-utils.js
+++ b/__tests__/html-utils.js
@@ -1,0 +1,306 @@
+'use strict';
+
+const AssetCss = require('../lib/asset-css');
+const AssetJs = require('../lib/asset-js');
+const utils = require('../lib/html-utils');
+
+/**
+ * .buildLinkElement()
+ */
+
+test('.buildLinkElement() - "value" property has a value - should appended "href" attribute to element', () => {
+    const obj = new AssetCss({
+        value: '/foo'
+    });
+    const result = utils.buildLinkElement(obj);
+    expect(result).toEqual('<link href="/foo" type="text/css" rel="stylesheet">');
+});
+
+test('.buildLinkElement() - "crossorigin" property has a value - should appended "crossorigin" attribute to element', () => {
+    const obj = new AssetCss({
+        value: '/foo',
+        crossorigin: 'bar'
+    });
+    const result = utils.buildLinkElement(obj);
+    expect(result).toEqual('<link href="/foo" crossorigin="bar" type="text/css" rel="stylesheet">');
+});
+
+test('.buildLinkElement() - "disabled" property is "true" - should appended "disabled" attribute to element', () => {
+    const obj = new AssetCss({
+        value: '/foo',
+        disabled: true
+    });
+    const result = utils.buildLinkElement(obj);
+    expect(result).toEqual('<link href="/foo" disabled type="text/css" rel="stylesheet">');
+});
+
+test('.buildLinkElement() - "hreflang" property has a value - should appended "hreflang" attribute to element', () => {
+    const obj = new AssetCss({
+        value: '/foo',
+        hreflang: 'bar'
+    });
+    const result = utils.buildLinkElement(obj);
+    expect(result).toEqual('<link href="/foo" hreflang="bar" type="text/css" rel="stylesheet">');
+});
+
+test('.buildLinkElement() - "title" property has a value - should appended "title" attribute to element', () => {
+    const obj = new AssetCss({
+        value: '/foo',
+        title: 'bar'
+    });
+    const result = utils.buildLinkElement(obj);
+    expect(result).toEqual('<link href="/foo" title="bar" type="text/css" rel="stylesheet">');
+});
+
+test('.buildLinkElement() - "media" property has a value - should appended "media" attribute to element', () => {
+    const obj = new AssetCss({
+        value: '/foo',
+        media: 'bar'
+    });
+    const result = utils.buildLinkElement(obj);
+    expect(result).toEqual('<link href="/foo" media="bar" type="text/css" rel="stylesheet">');
+});
+
+test('.buildLinkElement() - "as" property has a value - should appended "as" attribute to element', () => {
+    const obj = new AssetCss({
+        value: '/foo',
+        as: 'bar'
+    });
+    const result = utils.buildLinkElement(obj);
+    expect(result).toEqual('<link href="/foo" as="bar" type="text/css" rel="stylesheet">');
+});
+
+test('.buildLinkElement() - "type" property has a value - should appended "type" attribute to element', () => {
+    const obj = new AssetCss({
+        value: '/foo',
+        type: 'bar'
+    });
+    const result = utils.buildLinkElement(obj);
+    expect(result).toEqual('<link href="/foo" type="bar" rel="stylesheet">');
+});
+
+test('.buildLinkElement() - "rel" property has a value - should appended "rel" attribute to element', () => {
+    const obj = new AssetCss({
+        value: '/foo',
+        rel: 'bar'
+    });
+    const result = utils.buildLinkElement(obj);
+    expect(result).toEqual('<link href="/foo" type="text/css" rel="bar">');
+});
+
+test('.buildLinkElement() - properties are "undefined" - should NOT appended attributes to element', () => {
+    const obj = new AssetCss({
+        crossorigin: undefined,
+        disabled: undefined,
+        hreflang: undefined,
+        title: undefined,
+        media: undefined,
+        value: '/foo',
+        type: undefined,
+        rel: undefined,
+        as: undefined,
+    });
+    const result = utils.buildLinkElement(obj);
+    expect(result).toEqual('<link href="/foo" type="text/css" rel="stylesheet">');
+});
+
+test('.buildLinkElement() - properties are "null" - should NOT appended attributes to element', () => {
+    const obj = new AssetCss({
+        crossorigin: null,
+        disabled: null,
+        hreflang: null,
+        title: null,
+        media: null,
+        value: '/foo',
+        type: null,
+        rel: null,
+        as: null,
+    });
+    const result = utils.buildLinkElement(obj);
+    expect(result).toEqual('<link href="/foo">');
+});
+
+test('.buildLinkElement() - properties are "false" - should NOT appended attributes to element', () => {
+    const obj = new AssetCss({
+        crossorigin: false,
+        disabled: false,
+        hreflang: false,
+        title: false,
+        media: false,
+        value: '/foo',
+        type: false,
+        rel: false,
+        as: false,
+    });
+    const result = utils.buildLinkElement(obj);
+    expect(result).toEqual('<link href="/foo">');
+});
+
+test('.buildLinkElement() - properties are empty string - should NOT appended attributes to element', () => {
+    const obj = new AssetCss({
+        crossorigin: '',
+        disabled: '',
+        hreflang: '',
+        title: '',
+        media: '',
+        value: '/foo',
+        type: '',
+        rel: '',
+        as: '',
+    });
+    const result = utils.buildLinkElement(obj);
+    expect(result).toEqual('<link href="/foo">');
+});
+
+/**
+ * .buildScriptElement()
+ */
+
+test('.buildScriptElement() - "value" property has a value - should appended "src" attribute to element', () => {
+    const obj = new AssetJs({
+        value: '/foo'
+    });
+    const result = utils.buildScriptElement(obj);
+    expect(result).toEqual('<script src="/foo"></script>');
+});
+
+test('.buildScriptElement() - "type" property has "module" as value - should appended "type" attribute with "module" as value to element', () => {
+    const obj = new AssetJs({
+        value: '/foo',
+        type: 'module'
+    });
+    const result = utils.buildScriptElement(obj);
+    expect(result).toEqual('<script src="/foo" type="module"></script>');
+});
+
+test('.buildScriptElement() - "type" property has "esm" as value - should appended "type" attribute with "module" as value to element', () => {
+    const obj = new AssetJs({
+        value: '/foo',
+        type: 'esm'
+    });
+    const result = utils.buildScriptElement(obj);
+    expect(result).toEqual('<script src="/foo" type="module"></script>');
+});
+
+test('.buildScriptElement() - "type" property has "cjs" as value - should NOT appended a attribute to element', () => {
+    const obj = new AssetJs({
+        value: '/foo',
+        type: 'cjs'
+    });
+    const result = utils.buildScriptElement(obj);
+    expect(result).toEqual('<script src="/foo"></script>');
+});
+
+test('.buildScriptElement() - "referrerpolicy" property has a value - should appended "referrerpolicy" attribute to element', () => {
+    const obj = new AssetJs({
+        value: '/foo',
+        referrerpolicy: 'bar'
+    });
+    const result = utils.buildScriptElement(obj);
+    expect(result).toEqual('<script src="/foo" referrerpolicy="bar"></script>');
+});
+
+test('.buildScriptElement() - "crossorigin" property has a value - should appended "crossorigin" attribute to element', () => {
+    const obj = new AssetJs({
+        value: '/foo',
+        crossorigin: 'bar'
+    });
+    const result = utils.buildScriptElement(obj);
+    expect(result).toEqual('<script src="/foo" crossorigin="bar"></script>');
+});
+
+test('.buildScriptElement() - "integrity" property has a value - should appended "integrity" attribute to element', () => {
+    const obj = new AssetJs({
+        value: '/foo',
+        integrity: 'bar'
+    });
+    const result = utils.buildScriptElement(obj);
+    expect(result).toEqual('<script src="/foo" integrity="bar"></script>');
+});
+
+test('.buildScriptElement() - "nomodule" property is "true" - should appended "nomodule" attribute to element', () => {
+    const obj = new AssetJs({
+        value: '/foo',
+        nomodule: true
+    });
+    const result = utils.buildScriptElement(obj);
+    expect(result).toEqual('<script src="/foo" nomodule></script>');
+});
+
+test('.buildScriptElement() - "async" property is "true" - should appended "async" attribute to element', () => {
+    const obj = new AssetJs({
+        value: '/foo',
+        async: true
+    });
+    const result = utils.buildScriptElement(obj);
+    expect(result).toEqual('<script src="/foo" async></script>');
+});
+
+test('.buildScriptElement() - "defer" property is "true" - should appended "defer" attribute to element', () => {
+    const obj = new AssetJs({
+        value: '/foo',
+        defer: true
+    });
+    const result = utils.buildScriptElement(obj);
+    expect(result).toEqual('<script src="/foo" defer></script>');
+});
+
+test('.buildScriptElement() - properties are "undefined" - should NOT appended attributes to element', () => {
+    const obj = new AssetJs({
+        referrerpolicy: undefined,
+        crossorigin: undefined,
+        integrity: undefined,
+        nomodule: undefined,
+        async: undefined,
+        defer: undefined,
+        value: '/foo',
+        type: undefined,
+    });
+    const result = utils.buildScriptElement(obj);
+    expect(result).toEqual('<script src="/foo"></script>');
+});
+
+test('.buildScriptElement() - properties are "null" - should NOT appended attributes to element', () => {
+    const obj = new AssetJs({
+        referrerpolicy: null,
+        crossorigin: null,
+        integrity: null,
+        nomodule: null,
+        async: null,
+        defer: null,
+        value: '/foo',
+        type: null,
+    });
+    const result = utils.buildScriptElement(obj);
+    expect(result).toEqual('<script src="/foo"></script>');
+});
+
+test('.buildScriptElement() - properties are "false" - should NOT appended attributes to element', () => {
+    const obj = new AssetJs({
+        referrerpolicy: false,
+        crossorigin: false,
+        integrity: false,
+        nomodule: false,
+        async: false,
+        defer: false,
+        value: '/foo',
+        type: false,
+    });
+    const result = utils.buildScriptElement(obj);
+    expect(result).toEqual('<script src="/foo"></script>');
+});
+
+test('.buildScriptElement() - properties are empty string - should NOT appended attributes to element', () => {
+    const obj = new AssetJs({
+        referrerpolicy: '',
+        crossorigin: '',
+        integrity: '',
+        nomodule: '',
+        async: '',
+        defer: '',
+        value: '/foo',
+        type: '',
+    });
+    const result = utils.buildScriptElement(obj);
+    expect(result).toEqual('<script src="/foo"></script>');
+});

--- a/lib/asset-css.js
+++ b/lib/asset-css.js
@@ -2,6 +2,7 @@
 
 const { validate } = require('@podium/schemas');
 const { uriIsRelative, pathnameBuilder } = require('./utils');
+const { buildLinkElement } = require('./html-utils');
 
 // Ref: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link
 // NOTE: Only includes attributes used for loading CSS
@@ -22,12 +23,6 @@ const toUndefined = value => {
     if (value === false) return undefined;
     if (value === '') return undefined;
     return value;
-};
-
-const notEmpty = value => {
-    if (value === false) return value;
-    if (value !== '') return true;
-    return false;
 };
 
 const PodiumAssetCss = class PodiumAssetCss {
@@ -160,38 +155,7 @@ const PodiumAssetCss = class PodiumAssetCss {
     }
 
     toHTML() {
-        const args = [];
-
-        args.push(`href="${this.href}"`);
-
-        if (notEmpty(this.crossorigin)) {
-            args.push(`crossorigin="${this.crossorigin}"`);
-        }
-
-        if (notEmpty(this.disabled)) {
-            args.push('disabled');
-        }
-
-        if (notEmpty(this.hreflang)) {
-            args.push(`hreflang="${this.hreflang}"`);
-        }
-
-        if (notEmpty(this.title)) {
-            args.push(`title="${this.title}"`);
-        }
-
-        if (notEmpty(this.media)) {
-            args.push(`media="${this.media}"`);
-        }
-
-        if (notEmpty(this.as)) {
-            args.push(`as="${this.as}"`);
-        }
-
-        args.push(`type="${this.type}"`);
-        args.push(`rel="${this.rel}"`);
-
-        return `<link ${args.join(' ')}>`;
+        return buildLinkElement(this);
     }
 
     get [Symbol.toStringTag]() {

--- a/lib/asset-js.js
+++ b/lib/asset-js.js
@@ -2,6 +2,7 @@
 
 const { validate } = require('@podium/schemas');
 const { uriIsRelative, pathnameBuilder } = require('./utils');
+const { buildScriptElement } = require('./html-utils');
 
 // Ref: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script
 // NOTE: "nonce" is deliberately left out since we do not support inline scripts
@@ -21,12 +22,6 @@ const toUndefined = value => {
     if (value === false) return undefined;
     if (value === '') return undefined;
     return value;
-};
-
-const notEmpty = value => {
-    if (value === false) return value;
-    if (value !== '') return true;
-    return false;
 };
 
 const PodiumAssetJs = class PodiumAssetJs {
@@ -148,39 +143,7 @@ const PodiumAssetJs = class PodiumAssetJs {
     }
 
     toHTML() {
-        const args = [];
-
-        args.push(`src="${this.src}"`);
-
-        if (this.type === 'esm' || this.type === 'module') {
-            args.push('type="module"');
-        }
-
-        if (notEmpty(this.referrerpolicy)) {
-            args.push(`referrerpolicy="${this.referrerpolicy}"`);
-        }
-
-        if (notEmpty(this.crossorigin)) {
-            args.push(`crossorigin="${this.crossorigin}"`);
-        }
-
-        if (notEmpty(this.integrity)) {
-            args.push(`integrity="${this.integrity}"`);
-        }
-
-        if (notEmpty(this.nomodule)) {
-            args.push('nomodule');
-        }
-
-        if (notEmpty(this.async)) {
-            args.push('async');
-        }
-
-        if (notEmpty(this.defer)) {
-            args.push('defer');
-        }
-
-        return `<script ${args.join(' ')}></script>`;
+        return buildScriptElement(this);
     }
 
     get [Symbol.toStringTag]() {

--- a/lib/html-document.js
+++ b/lib/html-document.js
@@ -1,15 +1,6 @@
 'use strict';
 
-const buildScriptTag = ({ value = '', type = 'default' }) => {
-    if (type === 'esm') {
-        return `<script type="module" defer src="${value}" ></script>`;
-    }
-    return `<script defer src="${value}" ></script>`;
-};
-
-const buildCSSLinkTag = ({ value = '' }) => {
-    return `<link rel="stylesheet" type="text/css" href="${value}">`;
-};
+const utils = require('./html-utils');
 
 const document = (incoming = {}, body = '', head = '') => {
     let scripts = incoming.js;
@@ -17,7 +8,7 @@ const document = (incoming = {}, body = '', head = '') => {
 
     // backwards compatibility for scripts and styles
     if (typeof incoming.js === 'string') scripts = [{ type: 'default', value: incoming.js }];
-    if (typeof incoming.css === 'string') styles = [{ type: 'default', value: incoming.css }];
+    if (typeof incoming.css === 'string') styles = [{ type: 'text/css', value: incoming.css, rel: 'stylesheet' }];
 
     return `<!doctype html>
 <html lang="${incoming.context.locale ? incoming.context.locale : 'en-US'}">
@@ -25,8 +16,8 @@ const document = (incoming = {}, body = '', head = '') => {
         <meta charset="${incoming.view.encoding ? incoming.view.encoding : 'utf-8'}">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta http-equiv="X-UA-Compatible" content="IE=Edge">
-        ${styles.map(buildCSSLinkTag).join('\n        ')}
-        ${scripts.map(buildScriptTag).join('\n        ')}
+        ${styles.map(utils.buildLinkElement).join('\n        ')}
+        ${scripts.map(utils.buildScriptElement).join('\n        ')}
         <title>${incoming.view.title ? incoming.view.title : ''}</title>
         ${head}
     </head>

--- a/lib/html-utils.js
+++ b/lib/html-utils.js
@@ -1,0 +1,86 @@
+'use strict';
+
+const notEmpty = value => {
+    if (value === false) return value;
+    if (value === undefined) return false;
+    if (value === null) return false;
+    if (value !== '') return true;
+    return false;
+};
+
+const buildScriptElement = obj => {
+    const args = [];
+    args.push(`src="${obj.value}"`);
+
+    if (obj.type === 'esm' || obj.type === 'module') {
+        args.push('type="module"');
+    }
+
+    if (notEmpty(obj.referrerpolicy)) {
+        args.push(`referrerpolicy="${obj.referrerpolicy}"`);
+    }
+
+    if (notEmpty(obj.crossorigin)) {
+        args.push(`crossorigin="${obj.crossorigin}"`);
+    }
+
+    if (notEmpty(obj.integrity)) {
+        args.push(`integrity="${obj.integrity}"`);
+    }
+
+    if (notEmpty(obj.nomodule)) {
+        args.push('nomodule');
+    }
+
+    if (notEmpty(obj.async)) {
+        args.push('async');
+    }
+
+    if (notEmpty(obj.defer)) {
+        args.push('defer');
+    }
+
+    return `<script ${args.join(' ')}></script>`;
+};
+
+const buildLinkElement = obj => {
+    const args = [];
+    args.push(`href="${obj.value}"`);
+
+    if (notEmpty(obj.crossorigin)) {
+        args.push(`crossorigin="${obj.crossorigin}"`);
+    }
+
+    if (notEmpty(obj.disabled)) {
+        args.push('disabled');
+    }
+
+    if (notEmpty(obj.hreflang)) {
+        args.push(`hreflang="${obj.hreflang}"`);
+    }
+
+    if (notEmpty(obj.title)) {
+        args.push(`title="${obj.title}"`);
+    }
+
+    if (notEmpty(obj.media)) {
+        args.push(`media="${obj.media}"`);
+    }
+
+    if (notEmpty(obj.as)) {
+        args.push(`as="${obj.as}"`);
+    }
+
+    if (notEmpty(obj.type)) {
+        args.push(`type="${obj.type}"`);
+    }
+
+    if (notEmpty(obj.rel)) {
+        args.push(`rel="${obj.rel}"`);
+    }
+
+    return `<link ${args.join(' ')}>`;
+};
+
+module.exports.buildScriptElement = buildScriptElement;
+module.exports.buildLinkElement = buildLinkElement;

--- a/lib/main.js
+++ b/lib/main.js
@@ -5,6 +5,7 @@ const document = require('./html-document');
 const AssetCss = require('./asset-css');
 const AssetJs = require('./asset-js');
 const utils = require('./utils');
+const html = require('./html-utils');
 
 module.exports.isString = utils.isString;
 module.exports.isFunction = utils.isFunction;
@@ -17,6 +18,8 @@ module.exports.getFromLocalsPodium = utils.getFromLocalsPodium;
 module.exports.duplicateOnLocalsPodium = utils.duplicateOnLocalsPodium;
 module.exports.serializeContext = utils.serializeContext;
 module.exports.deserializeContext = utils.deserializeContext;
+module.exports.buildScriptElement = html.buildScriptElement;
+module.exports.buildLinkElement = html.buildLinkElement;
 module.exports.HttpIncoming = HttpIncoming;
 module.exports.template = document;
 module.exports.AssetCss = AssetCss;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@podium/utils",
-    "version": "4.1.0-next.1",
+    "version": "4.1.0-next.2",
     "description": "Common generic utility methods shared by @podium modules.",
     "license": "MIT",
     "keywords": [


### PR DESCRIPTION
This moves the methods for building html `<script>` and `<link>` elements out of the AssetCss and AssetJs classes introduced earlier. There methods are more or less extracted out of the AssetCss and AssetJs classes and made available as public methods so its easier for custom document-templates to use these.

The default document-template shipped with podium is now using these methods to build html `<script>` and `<link>` elements.