### PR TITLE
Added .podlets property to HttpIncoming

### DIFF
--- a/__tests__/http-incoming.js
+++ b/__tests__/http-incoming.js
@@ -176,6 +176,43 @@ test('PodiumHttpIncoming.view - set value - should set value', () => {
     });
 });
 
+test('PodiumHttpIncoming.podlets - set legal value - should append values to .css and .js', () => {
+    const incoming = new HttpIncoming(ADVANCED_REQ, SIMPLE_RES);
+    incoming.podlets = [
+        { css: [ { value: 'foo.css' } ], js: [ { value: 'foo.js' } ] },
+        { css: [ { value: 'bar.css' } ], js: [ { value: 'bar.js' } ] },
+    ];
+    expect(incoming.css).toEqual([{ value: 'foo.css' }, { value: 'bar.css' }]);
+    expect(incoming.js).toEqual([{ value: 'foo.js' }, { value: 'bar.js' }]);
+});
+
+test('PodiumHttpIncoming.podlets - set legal value - should append those values with .css and .js to .css and .js', () => {
+    const incoming = new HttpIncoming(ADVANCED_REQ, SIMPLE_RES);
+    incoming.podlets = [
+        { css: [ { value: 'foo.css' } ], js: [ { value: 'foo.js' } ] },
+        { css: [ { value: 'bar.css' } ], js: [ { value: 'bar.js' } ] },
+        { ssc: [ { value: 'xyz.css' } ], sj: [ { value: 'xyz.js' } ] },
+    ];
+    expect(incoming.css).toEqual([{ value: 'foo.css' }, { value: 'bar.css' }]);
+    expect(incoming.js).toEqual([{ value: 'foo.js' }, { value: 'bar.js' }]);
+});
+
+test('PodiumHttpIncoming.podlets - get illegal value - should throw', () => {
+    expect.hasAssertions();
+    const incoming = new HttpIncoming(ADVANCED_REQ, SIMPLE_RES);
+    expect(() => {
+        incoming.podlets = './foo.js';
+    }).toThrowError('Value for property ".podlets" must be an Array');
+});
+
+test('PodiumHttpIncoming.podlets - get value - should throw', () => {
+    expect.hasAssertions();
+    const incoming = new HttpIncoming(ADVANCED_REQ, SIMPLE_RES);
+    expect(() => {
+        incoming.podlets;
+    }).toThrowError('The getter for .podlets is reserved for later implementation');
+});
+
 test('PodiumHttpIncoming.toJSON() - call method - should return object without ".request" and ".response"', () => {
     const incoming = new HttpIncoming(SIMPLE_REQ, SIMPLE_RES);
     const result = incoming.toJSON();

--- a/lib/http-incoming.js
+++ b/lib/http-incoming.js
@@ -65,6 +65,32 @@ const PodiumHttpIncoming = class PodiumHttpIncoming {
         return this[_context];
     }
 
+    set podlets(value) {
+        if (!Array.isArray(value)) throw new Error(
+            `Value for property ".podlets" must be an Array`,
+        );
+
+        value.forEach(podlet => {
+            if (podlet.css) {
+                podlet.css.forEach(item => {
+                    this[_css].push(item);
+                });
+            }
+
+            if (podlet.js) {
+                podlet.js.forEach(item => {
+                    this[_js].push(item);
+                });
+            }
+        });
+    }
+
+    get podlets() {
+        throw new Error(
+            `The getter for .podlets is reserved for later implementation`,
+        );
+    }
+
     set params(value) {
         throw new Error('Cannot set read-only property.');
     }


### PR DESCRIPTION
This adds a `.podlets` property to `HttpIncoming` which accept an array of client responses and join the values for `.css` and `.js` on these responses into the `.css` and `.js` properties of `HttpIncoming`.

This is better explained with an example.

This is a bit simplified but when we are doing something like this in a Layout:

```js
layout.css({ value: 'layout.css' });
layout.js({ value: 'layout.js' });

[ ... ]

const incoming = res.locals.podium;
const podlets = await Promise.all([
    header.fetch(incoming),
    auth.fetch(incoming),
    geo.fetch(incoming),
    images.fetch(incoming),
    footer.fetch(incoming),
]);
```
the constant named `incoming` is an Object which holds the values set by `layout.css()` and `layout.js()` like so:

```js
{
    css: [ 'layout.css' ],
    js: [ 'layout.js' ],
}
```

and then the constant named `podlets` ends up with an Array which looks like this when the `Promise.all()` has resolved:

```js
[
    { content: '[...]', css: [ 'header.css' ], js: [ 'header.js' ] },
    { content: '[...]', css: [ 'auth.css' ], js: [ 'auth.js' ] },
    { content: '[...]', css: [ 'geo.css' ], js: [ 'geo.js' ] },
    { content: '[...]', css: [ 'images.css' ], js: [ 'images.js' ] },
    { content: '[...]', css: [ 'footer.css' ], js: [ 'footer.js' ] },
]
```

We are now left with css and js set for the layout in one Array and the css and js for all podlets in an array in an array of objects. In other words; when we want to turn this into HTML `<link>` and `<script>` tags in the document template, its not just one Array to iterate over. This needs to be massaged a bit so its easy to iterate over later.

This implementation makes this much easier. By setting the Array of the constant named `podlets` on the `.podlets` property of `incoming` all those css and js values in the Array of Objects will be pushed onto `.css` and `.js` of `incoming`. 

In other words, by doing so:

```js
layout.css({ value: 'layout.css' });
layout.js({ value: 'layout.js' });

[ ... ]

const incoming = res.locals.podium;
const podlets = await Promise.all([
    header.fetch(incoming),
    auth.fetch(incoming),
    geo.fetch(incoming),
    images.fetch(incoming),
    footer.fetch(incoming),
]);

incoming.podlets = podlets;
```

the `incoming` object will now be like this:

```js
{
    css: [ 'layout.css', 'header.css', 'auth.css', 'geo.css', 'images.css', 'footer.css' ],
    js: [ 'layout.js', 'header.js', 'auth.js', 'geo.js', 'images.js', 'footer.js' ],
}
```

## Setter only

Do note that this only adds a setter and not a getter. The getter is currently set to throw. 

In other words; doing so, which is super handy, will throw:

```js
const incoming = res.locals.podium;
incoming.podlets = await Promise.all([
    header.fetch(incoming),
    auth.fetch(incoming),
    geo.fetch(incoming),
    images.fetch(incoming),
    footer.fetch(incoming),
]);

console.log(incoming.podlets[0].content);  // throws
```

The reason for throwing on the getter as now, is because we want to make the use of `.podlets` into a even nicer API, but we are not able to until `.fetch()` and `.stream()` has a requirement of taking `HttpIncoming` as the first argument. That will happen in V5. 

Now we are just flattening out and joining the asset values.