### PR TITLE
support setting crossorigin to false, true and empty string

### DIFF
--- a/__tests__/asset-js.js
+++ b/__tests__/asset-js.js
@@ -21,7 +21,7 @@ test('Js() - no value given to "value" argument - should throw', () => {
 test('Js() - no arguments given - should construct object with default values', () => {
     const obj = new Js({ value: '/foo' });
     expect(obj.referrerpolicy).toEqual('');
-    expect(obj.crossorigin).toEqual('');
+    expect(obj.crossorigin).toEqual(undefined);
     expect(obj.integrity).toEqual('');
     expect(obj.nomodule).toEqual(false);
     expect(obj.async).toEqual(false);
@@ -36,7 +36,7 @@ test('Js() - no arguments given - should construct JSON with default values', ()
     const json = JSON.parse(JSON.stringify(obj));
     expect(json).toEqual({
         value: '/foo',
-        type: 'default'
+        type: 'default',
     });
 });
 
@@ -63,7 +63,7 @@ test('Js() - pathname is given - prefix is unset - should NOT append pathname to
     const json = JSON.parse(JSON.stringify(obj));
     expect(json).toEqual({
         value: '/foo',
-        type: 'default'
+        type: 'default',
     });
 });
 
@@ -72,7 +72,7 @@ test('Js() - pathname is given - prefix is false - should NOT append pathname to
     const json = JSON.parse(JSON.stringify(obj));
     expect(json).toEqual({
         value: '/foo',
-        type: 'default'
+        type: 'default',
     });
 });
 
@@ -81,7 +81,7 @@ test('Js() - pathname is given - prefix is true - should NOT append pathname to 
     const json = JSON.parse(JSON.stringify(obj));
     expect(json).toEqual({
         value: '/foo',
-        type: 'default'
+        type: 'default',
     });
 });
 
@@ -102,40 +102,42 @@ test('Js() - pathname is given - prefix is true - should append pathname to "src
 });
 
 test('Js() - value if absoulte - pathname is given - prefix is true - should NOT append pathname to "value"', () => {
-    const obj = new Js({ value: 'http://somewhere.else.com/foo', pathname: '/bar', prefix: true });
+    const obj = new Js({
+        value: 'http://somewhere.else.com/foo',
+        pathname: '/bar',
+        prefix: true,
+    });
     expect(obj.value).toEqual('http://somewhere.else.com/foo');
     expect(obj.src).toEqual('http://somewhere.else.com/foo');
 
     const json = JSON.parse(JSON.stringify(obj));
     expect(json).toEqual({
         value: 'http://somewhere.else.com/foo',
-        type: 'default'
+        type: 'default',
     });
 
-    expect(obj.toHTML()).toEqual('<script src="http://somewhere.else.com/foo"></script>');
+    expect(obj.toHTML()).toEqual(
+        '<script src="http://somewhere.else.com/foo"></script>',
+    );
 });
-
-
-
-
-
-
 
 test('Js() - set "referrerpolicy" - should construct object as expected', () => {
     const obj = new Js({
-        value: '/foo'
+        value: '/foo',
     });
 
     obj.referrerpolicy = 'bar';
 
     expect(obj.referrerpolicy).toEqual('bar');
-    expect(obj.toHTML()).toEqual('<script src="/foo" referrerpolicy="bar"></script>');
+    expect(obj.toHTML()).toEqual(
+        '<script src="/foo" referrerpolicy="bar"></script>',
+    );
 
     const json = JSON.parse(JSON.stringify(obj));
     expect(json).toEqual({
         referrerpolicy: 'bar',
         value: '/foo',
-        type: 'default'
+        type: 'default',
     });
 
     const repl = new Js(json);
@@ -144,19 +146,21 @@ test('Js() - set "referrerpolicy" - should construct object as expected', () => 
 
 test('Js() - set "crossorigin" - should construct object as expected', () => {
     const obj = new Js({
-        value: '/foo'
+        value: '/foo',
     });
 
     obj.crossorigin = 'bar';
 
     expect(obj.crossorigin).toEqual('bar');
-    expect(obj.toHTML()).toEqual('<script src="/foo" crossorigin="bar"></script>');
+    expect(obj.toHTML()).toEqual(
+        '<script src="/foo" crossorigin="bar"></script>',
+    );
 
     const json = JSON.parse(JSON.stringify(obj));
     expect(json).toEqual({
         crossorigin: 'bar',
         value: '/foo',
-        type: 'default'
+        type: 'default',
     });
 
     const repl = new Js(json);
@@ -165,19 +169,21 @@ test('Js() - set "crossorigin" - should construct object as expected', () => {
 
 test('Js() - set "integrity" - should construct object as expected', () => {
     const obj = new Js({
-        value: '/foo'
+        value: '/foo',
     });
 
     obj.integrity = 'bar';
 
     expect(obj.integrity).toEqual('bar');
-    expect(obj.toHTML()).toEqual('<script src="/foo" integrity="bar"></script>');
+    expect(obj.toHTML()).toEqual(
+        '<script src="/foo" integrity="bar"></script>',
+    );
 
     const json = JSON.parse(JSON.stringify(obj));
     expect(json).toEqual({
         integrity: 'bar',
         value: '/foo',
-        type: 'default'
+        type: 'default',
     });
 
     const repl = new Js(json);
@@ -186,7 +192,7 @@ test('Js() - set "integrity" - should construct object as expected', () => {
 
 test('Js() - set "nomodule" - should construct object as expected', () => {
     const obj = new Js({
-        value: '/foo'
+        value: '/foo',
     });
 
     obj.nomodule = true;
@@ -198,7 +204,7 @@ test('Js() - set "nomodule" - should construct object as expected', () => {
     expect(json).toEqual({
         nomodule: true,
         value: '/foo',
-        type: 'default'
+        type: 'default',
     });
 
     const repl = new Js(json);
@@ -207,7 +213,7 @@ test('Js() - set "nomodule" - should construct object as expected', () => {
 
 test('Js() - set "async" - should construct object as expected', () => {
     const obj = new Js({
-        value: '/foo'
+        value: '/foo',
     });
 
     obj.async = true;
@@ -219,7 +225,7 @@ test('Js() - set "async" - should construct object as expected', () => {
     expect(json).toEqual({
         async: true,
         value: '/foo',
-        type: 'default'
+        type: 'default',
     });
 
     const repl = new Js(json);
@@ -228,7 +234,7 @@ test('Js() - set "async" - should construct object as expected', () => {
 
 test('Js() - set "defer" - should construct object as expected', () => {
     const obj = new Js({
-        value: '/foo'
+        value: '/foo',
     });
 
     obj.defer = true;
@@ -240,7 +246,7 @@ test('Js() - set "defer" - should construct object as expected', () => {
     expect(json).toEqual({
         defer: true,
         value: '/foo',
-        type: 'default'
+        type: 'default',
     });
 
     const repl = new Js(json);
@@ -249,7 +255,7 @@ test('Js() - set "defer" - should construct object as expected', () => {
 
 test('Js() - set "type" - should construct object as expected', () => {
     const obj = new Js({
-        value: '/foo'
+        value: '/foo',
     });
 
     obj.type = 'esm';
@@ -260,7 +266,7 @@ test('Js() - set "type" - should construct object as expected', () => {
     const json = JSON.parse(JSON.stringify(obj));
     expect(json).toEqual({
         value: '/foo',
-        type: 'esm'
+        type: 'esm',
     });
 
     const repl = new Js(json);
@@ -270,7 +276,7 @@ test('Js() - set "type" - should construct object as expected', () => {
 test('Js() - set "value" - should throw', () => {
     expect.hasAssertions();
     const obj = new Js({
-        value: '/foo'
+        value: '/foo',
     });
     expect(() => {
         obj.value = '/bar';
@@ -280,7 +286,7 @@ test('Js() - set "value" - should throw', () => {
 test('Js() - set "src" - should throw', () => {
     expect.hasAssertions();
     const obj = new Js({
-        value: '/foo'
+        value: '/foo',
     });
     expect(() => {
         obj.src = '/bar';

--- a/__tests__/html-utils.js
+++ b/__tests__/html-utils.js
@@ -10,70 +10,84 @@ const utils = require('../lib/html-utils');
 
 test('.buildLinkElement() - "value" property has a value - should appended "href" attribute to element', () => {
     const obj = new AssetCss({
-        value: '/foo'
+        value: '/foo',
     });
     const result = utils.buildLinkElement(obj);
-    expect(result).toEqual('<link href="/foo" type="text/css" rel="stylesheet">');
+    expect(result).toEqual(
+        '<link href="/foo" type="text/css" rel="stylesheet">',
+    );
 });
 
 test('.buildLinkElement() - "crossorigin" property has a value - should appended "crossorigin" attribute to element', () => {
     const obj = new AssetCss({
         value: '/foo',
-        crossorigin: 'bar'
+        crossorigin: 'bar',
     });
     const result = utils.buildLinkElement(obj);
-    expect(result).toEqual('<link href="/foo" crossorigin="bar" type="text/css" rel="stylesheet">');
+    expect(result).toEqual(
+        '<link href="/foo" crossorigin="bar" type="text/css" rel="stylesheet">',
+    );
 });
 
 test('.buildLinkElement() - "disabled" property is "true" - should appended "disabled" attribute to element', () => {
     const obj = new AssetCss({
         value: '/foo',
-        disabled: true
+        disabled: true,
     });
     const result = utils.buildLinkElement(obj);
-    expect(result).toEqual('<link href="/foo" disabled type="text/css" rel="stylesheet">');
+    expect(result).toEqual(
+        '<link href="/foo" disabled type="text/css" rel="stylesheet">',
+    );
 });
 
 test('.buildLinkElement() - "hreflang" property has a value - should appended "hreflang" attribute to element', () => {
     const obj = new AssetCss({
         value: '/foo',
-        hreflang: 'bar'
+        hreflang: 'bar',
     });
     const result = utils.buildLinkElement(obj);
-    expect(result).toEqual('<link href="/foo" hreflang="bar" type="text/css" rel="stylesheet">');
+    expect(result).toEqual(
+        '<link href="/foo" hreflang="bar" type="text/css" rel="stylesheet">',
+    );
 });
 
 test('.buildLinkElement() - "title" property has a value - should appended "title" attribute to element', () => {
     const obj = new AssetCss({
         value: '/foo',
-        title: 'bar'
+        title: 'bar',
     });
     const result = utils.buildLinkElement(obj);
-    expect(result).toEqual('<link href="/foo" title="bar" type="text/css" rel="stylesheet">');
+    expect(result).toEqual(
+        '<link href="/foo" title="bar" type="text/css" rel="stylesheet">',
+    );
 });
 
 test('.buildLinkElement() - "media" property has a value - should appended "media" attribute to element', () => {
     const obj = new AssetCss({
         value: '/foo',
-        media: 'bar'
+        media: 'bar',
     });
     const result = utils.buildLinkElement(obj);
-    expect(result).toEqual('<link href="/foo" media="bar" type="text/css" rel="stylesheet">');
+    expect(result).toEqual(
+        '<link href="/foo" media="bar" type="text/css" rel="stylesheet">',
+    );
 });
 
 test('.buildLinkElement() - "as" property has a value - should appended "as" attribute to element', () => {
     const obj = new AssetCss({
         value: '/foo',
-        as: 'bar'
+        as: 'bar',
     });
     const result = utils.buildLinkElement(obj);
-    expect(result).toEqual('<link href="/foo" as="bar" type="text/css" rel="stylesheet">');
+    expect(result).toEqual(
+        '<link href="/foo" as="bar" type="text/css" rel="stylesheet">',
+    );
 });
 
 test('.buildLinkElement() - "type" property has a value - should appended "type" attribute to element', () => {
     const obj = new AssetCss({
         value: '/foo',
-        type: 'bar'
+        type: 'bar',
     });
     const result = utils.buildLinkElement(obj);
     expect(result).toEqual('<link href="/foo" type="bar" rel="stylesheet">');
@@ -82,7 +96,7 @@ test('.buildLinkElement() - "type" property has a value - should appended "type"
 test('.buildLinkElement() - "rel" property has a value - should appended "rel" attribute to element', () => {
     const obj = new AssetCss({
         value: '/foo',
-        rel: 'bar'
+        rel: 'bar',
     });
     const result = utils.buildLinkElement(obj);
     expect(result).toEqual('<link href="/foo" type="text/css" rel="bar">');
@@ -101,7 +115,9 @@ test('.buildLinkElement() - properties are "undefined" - should NOT appended att
         as: undefined,
     });
     const result = utils.buildLinkElement(obj);
-    expect(result).toEqual('<link href="/foo" type="text/css" rel="stylesheet">');
+    expect(result).toEqual(
+        '<link href="/foo" type="text/css" rel="stylesheet">',
+    );
 });
 
 test('.buildLinkElement() - properties are "null" - should NOT appended attributes to element', () => {
@@ -158,7 +174,7 @@ test('.buildLinkElement() - properties are empty string - should NOT appended at
 
 test('.buildScriptElement() - "value" property has a value - should appended "src" attribute to element', () => {
     const obj = new AssetJs({
-        value: '/foo'
+        value: '/foo',
     });
     const result = utils.buildScriptElement(obj);
     expect(result).toEqual('<script src="/foo"></script>');
@@ -167,7 +183,7 @@ test('.buildScriptElement() - "value" property has a value - should appended "sr
 test('.buildScriptElement() - "type" property has "module" as value - should appended "type" attribute with "module" as value to element', () => {
     const obj = new AssetJs({
         value: '/foo',
-        type: 'module'
+        type: 'module',
     });
     const result = utils.buildScriptElement(obj);
     expect(result).toEqual('<script src="/foo" type="module"></script>');
@@ -176,7 +192,7 @@ test('.buildScriptElement() - "type" property has "module" as value - should app
 test('.buildScriptElement() - "type" property has "esm" as value - should appended "type" attribute with "module" as value to element', () => {
     const obj = new AssetJs({
         value: '/foo',
-        type: 'esm'
+        type: 'esm',
     });
     const result = utils.buildScriptElement(obj);
     expect(result).toEqual('<script src="/foo" type="module"></script>');
@@ -185,7 +201,7 @@ test('.buildScriptElement() - "type" property has "esm" as value - should append
 test('.buildScriptElement() - "type" property has "cjs" as value - should NOT appended a attribute to element', () => {
     const obj = new AssetJs({
         value: '/foo',
-        type: 'cjs'
+        type: 'cjs',
     });
     const result = utils.buildScriptElement(obj);
     expect(result).toEqual('<script src="/foo"></script>');
@@ -194,7 +210,7 @@ test('.buildScriptElement() - "type" property has "cjs" as value - should NOT ap
 test('.buildScriptElement() - "referrerpolicy" property has a value - should appended "referrerpolicy" attribute to element', () => {
     const obj = new AssetJs({
         value: '/foo',
-        referrerpolicy: 'bar'
+        referrerpolicy: 'bar',
     });
     const result = utils.buildScriptElement(obj);
     expect(result).toEqual('<script src="/foo" referrerpolicy="bar"></script>');
@@ -203,7 +219,7 @@ test('.buildScriptElement() - "referrerpolicy" property has a value - should app
 test('.buildScriptElement() - "crossorigin" property has a value - should appended "crossorigin" attribute to element', () => {
     const obj = new AssetJs({
         value: '/foo',
-        crossorigin: 'bar'
+        crossorigin: 'bar',
     });
     const result = utils.buildScriptElement(obj);
     expect(result).toEqual('<script src="/foo" crossorigin="bar"></script>');
@@ -212,7 +228,7 @@ test('.buildScriptElement() - "crossorigin" property has a value - should append
 test('.buildScriptElement() - "integrity" property has a value - should appended "integrity" attribute to element', () => {
     const obj = new AssetJs({
         value: '/foo',
-        integrity: 'bar'
+        integrity: 'bar',
     });
     const result = utils.buildScriptElement(obj);
     expect(result).toEqual('<script src="/foo" integrity="bar"></script>');
@@ -221,7 +237,7 @@ test('.buildScriptElement() - "integrity" property has a value - should appended
 test('.buildScriptElement() - "nomodule" property is "true" - should appended "nomodule" attribute to element', () => {
     const obj = new AssetJs({
         value: '/foo',
-        nomodule: true
+        nomodule: true,
     });
     const result = utils.buildScriptElement(obj);
     expect(result).toEqual('<script src="/foo" nomodule></script>');
@@ -230,7 +246,7 @@ test('.buildScriptElement() - "nomodule" property is "true" - should appended "n
 test('.buildScriptElement() - "async" property is "true" - should appended "async" attribute to element', () => {
     const obj = new AssetJs({
         value: '/foo',
-        async: true
+        async: true,
     });
     const result = utils.buildScriptElement(obj);
     expect(result).toEqual('<script src="/foo" async></script>');
@@ -239,7 +255,7 @@ test('.buildScriptElement() - "async" property is "true" - should appended "asyn
 test('.buildScriptElement() - "defer" property is "true" - should appended "defer" attribute to element', () => {
     const obj = new AssetJs({
         value: '/foo',
-        defer: true
+        defer: true,
     });
     const result = utils.buildScriptElement(obj);
     expect(result).toEqual('<script src="/foo" defer></script>');
@@ -293,7 +309,6 @@ test('.buildScriptElement() - properties are "false" - should NOT appended attri
 test('.buildScriptElement() - properties are empty string - should NOT appended attributes to element', () => {
     const obj = new AssetJs({
         referrerpolicy: '',
-        crossorigin: '',
         integrity: '',
         nomodule: '',
         async: '',
@@ -303,4 +318,31 @@ test('.buildScriptElement() - properties are empty string - should NOT appended 
     });
     const result = utils.buildScriptElement(obj);
     expect(result).toEqual('<script src="/foo"></script>');
+});
+
+test('.buildScriptElement() - crossorigin empty string', () => {
+    const obj = new AssetJs({
+        crossorigin: '',
+        value: '/foo',
+    });
+    const result = utils.buildScriptElement(obj);
+    expect(result).toEqual(`<script src="/foo" crossorigin=""></script>`);
+});
+
+test('.buildScriptElement() - crossorigin boolean true', () => {
+    const obj = new AssetJs({
+        crossorigin: true,
+        value: '/bar',
+    });
+    const result = utils.buildScriptElement(obj);
+    expect(result).toEqual(`<script src="/bar" crossorigin></script>`);
+});
+
+test('.buildScriptElement() - crossorigin boolean false', () => {
+    const obj = new AssetJs({
+        crossorigin: false,
+        value: '/bar',
+    });
+    const result = utils.buildScriptElement(obj);
+    expect(result).toEqual(`<script src="/bar"></script>`);
 });

--- a/lib/asset-js.js
+++ b/lib/asset-js.js
@@ -27,7 +27,7 @@ const toUndefined = value => {
 const PodiumAssetJs = class PodiumAssetJs {
     constructor({
         referrerpolicy = '',
-        crossorigin = '',
+        crossorigin = undefined,
         integrity = '',
         pathname = '',
         nomodule = false,
@@ -132,7 +132,7 @@ const PodiumAssetJs = class PodiumAssetJs {
     toJSON() {
         return {
             referrerpolicy: toUndefined(this.referrerpolicy),
-            crossorigin: toUndefined(this.crossorigin),
+            crossorigin: this.crossorigin,
             integrity: toUndefined(this.integrity),
             nomodule: toUndefined(this.nomodule),
             value: this[_value],

--- a/lib/html-utils.js
+++ b/lib/html-utils.js
@@ -20,8 +20,9 @@ const buildScriptElement = obj => {
         args.push(`referrerpolicy="${obj.referrerpolicy}"`);
     }
 
-    if (notEmpty(obj.crossorigin)) {
-        args.push(`crossorigin="${obj.crossorigin}"`);
+    if (obj.crossorigin || obj.crossorigin === '') {
+        if (obj.crossorigin === true) args.push(`crossorigin`);
+        else args.push(`crossorigin="${obj.crossorigin}"`);
     }
 
     if (notEmpty(obj.integrity)) {


### PR DESCRIPTION
Both of the following are valid:

```js
<script src="/foo" crossorigin></script>
<script src="/foo" crossorigin=""></script>
```

However, it was not possible to set an empty string or indicate that the boolean form should be used. 

This PR makes it possible to set boolean true/false or a string as in:

```js
new AssetJs({ crossorigin: true });
new AssetJs({ crossorigin: false });
new AssetJs({ crossorigin: '' });
new AssetJs({ crossorigin: 'anonymous' });
```