### PR TITLE
Parse out protocol

### DIFF
--- a/lib/http-incoming.js
+++ b/lib/http-incoming.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const originalUrl = require('original-url');
 const { URL } = require('url');
 
 const _development = Symbol('podium:httpincoming:development');
@@ -15,9 +16,11 @@ const _css = Symbol('podium:httpincoming:css');
 const _js = Symbol('podium:httpincoming:js');
 
 const protocolFromRequest = (request = {}) => {
-    const secure =
-        request.secure || (request.connection && request.connection.encrypted);
-    return secure ? 'https:' : 'http:';
+    if (request.headers) {
+        const url = originalUrl(request);
+        return url.protocol ? url.protocol : 'http:';
+    }
+    return 'http:';
 };
 
 const urlFromRequest = (request, protocol) => {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     },
     "dependencies": {
         "@podium/schemas": "4.0.1",
+        "original-url": "1.2.3",
         "camelcase": "5.3.1"
     }
 }


### PR DESCRIPTION
This parses out the protocol based on the `forwarded` header. We're ignoring the rest of the header as is. This is a temporary fix related to that we lost protocol in the context.