### PR TITLE
Support original url

### DIFF
--- a/__tests__/http-incoming.js
+++ b/__tests__/http-incoming.js
@@ -52,6 +52,54 @@ test('PodiumHttpIncoming() - "request" argument given - should set parsed URL on
     expect(incoming.url.host).toEqual('localhost:3030');
     expect(incoming.url.port).toEqual('3030');
     expect(incoming.url.protocol).toEqual('http:');
+    expect(incoming.url.pathname).toEqual('/some/path');
+});
+
+test('PodiumHttpIncoming() - has forwarded - should set ignore hostname and use host', () => {
+    const incoming = new HttpIncoming({
+        headers: {
+            host: 'localhost:3030',
+            'forwarded': 'host=example.com; proto=https'
+        },
+        hostname: 'localhost',
+        url: '/some/path',
+    });
+    expect(incoming.url.hostname).toEqual('localhost');
+    expect(incoming.url.host).toEqual('localhost:3030');
+    expect(incoming.url.port).toEqual('3030');
+    expect(incoming.url.protocol).toEqual('https:');
+    expect(incoming.url.pathname).toEqual('/some/path');
+});
+
+test('PodiumHttpIncoming() - forwarded https request - should set ".url.protocol" to https', () => {
+    const incoming = new HttpIncoming({
+        headers: {
+            host: 'localhost:3030',
+            'x-forwarded-proto': 'https',
+        },
+        hostname: 'localhost',
+        url: '/some/path',
+    });
+    expect(incoming.url.hostname).toEqual('localhost');
+    expect(incoming.url.host).toEqual('localhost:3030');
+    expect(incoming.url.port).toEqual('3030');
+    expect(incoming.url.protocol).toEqual('https:');
+    expect(incoming.url.pathname).toEqual('/some/path');
+});
+
+test('PodiumHttpIncoming() - request has ".originalUrl" instead of ".url" - should set value of ".originalUrl" as ".url.pathname"', () => {
+    const incoming = new HttpIncoming({
+        headers: {
+            host: 'localhost:3030',
+        },
+        hostname: 'localhost',
+        originalUrl: '/some/path',
+    });
+    expect(incoming.url.hostname).toEqual('localhost');
+    expect(incoming.url.host).toEqual('localhost:3030');
+    expect(incoming.url.port).toEqual('3030');
+    expect(incoming.url.protocol).toEqual('http:');
+    expect(incoming.url.pathname).toEqual('/some/path');
 });
 
 test('PodiumHttpIncoming() - "response" argument given - should store request on ".response"', () => {
@@ -89,7 +137,6 @@ test('PodiumHttpIncoming.params - set value - should throw', () => {
 });
 
 test('PodiumHttpIncoming.url - set value - should set value', () => {
-    expect.hasAssertions();
     const incoming = new HttpIncoming(ADVANCED_REQ, SIMPLE_RES);
     incoming.url = 'foo';
     expect(incoming.url).toEqual('foo');

--- a/lib/http-incoming.js
+++ b/lib/http-incoming.js
@@ -15,17 +15,10 @@ const _url = Symbol('podium:httpincoming:url');
 const _css = Symbol('podium:httpincoming:css');
 const _js = Symbol('podium:httpincoming:js');
 
-const protocolFromRequest = (request = {}) => {
-    if (request.headers) {
-        const url = originalUrl(request);
-        return url.protocol ? url.protocol : 'http:';
-    }
-    return 'http:';
-};
-
-const urlFromRequest = (request, protocol) => {
+const urlFromRequest = (request) => {
     try {
-        return new URL(request.url, `${protocol}//${request.headers.host}`);
+        const url = originalUrl(request);
+        return new URL(url.pathname, `${url.protocol}//${request.headers.host}`);
     } catch (err) {
         return {};
     }
@@ -33,8 +26,7 @@ const urlFromRequest = (request, protocol) => {
 
 const PodiumHttpIncoming = class PodiumHttpIncoming {
     constructor(request = {}, response = {}, params = {}) {
-        const protocol = protocolFromRequest(request);
-        const url = urlFromRequest(request, protocol);
+        const url = urlFromRequest(request);
 
         // Private properties
         this[_development] = false;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@podium/utils",
-    "version": "4.2.0",
+    "version": "4.2.1",
     "description": "Common generic utility methods shared by @podium modules.",
     "license": "MIT",
     "keywords": [


### PR DESCRIPTION
In Express `request.url` is always `/`. This differ from how its in core node.js. To get the pathname of a URL in Express one need to use `request.originalUrl` instead. This PR caters for that.