### PR TITLE
feat: support for data attributes on script tags

### DIFF
--- a/__tests__/asset-js.js
+++ b/__tests__/asset-js.js
@@ -29,6 +29,7 @@ test('Js() - no arguments given - should construct object with default values', 
     expect(obj.value).toEqual('/foo');
     expect(obj.type).toEqual('default');
     expect(obj.src).toEqual('/foo');
+    expect(obj.data).toEqual(undefined);
 });
 
 test('Js() - no arguments given - should construct JSON with default values', () => {
@@ -271,6 +272,27 @@ test('Js() - set "type" - should construct object as expected', () => {
 
     const repl = new Js(json);
     expect(repl.type).toEqual('esm');
+});
+
+test('Js() - set "data" - should construct object as expected', () => {
+    const obj = new Js({
+        value: '/foo',
+    });
+
+    obj.data = { foo: 'bar' };
+
+    expect(obj.data).toEqual({ foo: 'bar' });
+    expect(obj.toHTML()).toEqual('<script src="/foo" data-foo="bar"></script>');
+
+    const json = JSON.parse(JSON.stringify(obj));
+    expect(json).toEqual({
+        value: '/foo',
+        data: { foo: 'bar' },
+        type: 'default',
+    });
+
+    const repl = new Js(json);
+    expect(repl.data).toEqual({ foo: 'bar' });
 });
 
 test('Js() - set "value" - should throw', () => {

--- a/__tests__/html-utils.js
+++ b/__tests__/html-utils.js
@@ -274,6 +274,15 @@ test('.buildScriptElement() - "async" property is "true" - should appended "asyn
     expect(result).toEqual('<script src="/foo" async></script>');
 });
 
+test('.buildScriptElement() - "data" property has a value - should appended "data" attribute to element', () => {
+    const obj = new AssetJs({
+        value: '/foo',
+        data: { foo: 'bar' },
+    });
+    const result = utils.buildScriptElement(obj);
+    expect(result).toEqual('<script src="/foo" data-foo="bar"></script>');
+});
+
 test('.buildScriptElement() - "defer" property is "true" - should appended "defer" attribute to element', () => {
     const obj = new AssetJs({
         value: '/foo',

--- a/lib/asset-js.js
+++ b/lib/asset-js.js
@@ -17,8 +17,9 @@ const _value = Symbol('podium:asset:js:value');
 const _async = Symbol('podium:asset:js:async');
 const _defer = Symbol('podium:asset:js:defer');
 const _type = Symbol('podium:asset:js:type');
+const _data = Symbol('podium:asset:js:data');
 
-const toUndefined = value => {
+const toUndefined = (value) => {
     if (value === false) return undefined;
     if (value === '') return undefined;
     return value;
@@ -36,6 +37,7 @@ const PodiumAssetJs = class PodiumAssetJs {
         async = false,
         defer = false,
         type = 'default',
+        data = undefined,
     } = {}) {
         if (validate.js(value).error)
             throw new Error(
@@ -53,6 +55,7 @@ const PodiumAssetJs = class PodiumAssetJs {
         this[_async] = async;
         this[_defer] = defer;
         this[_type] = type;
+        this[_data] = data;
     }
 
     get referrerpolicy() {
@@ -121,6 +124,14 @@ const PodiumAssetJs = class PodiumAssetJs {
         this[_type] = value;
     }
 
+    get data() {
+        return this[_data];
+    }
+
+    set data(value) {
+        this[_data] = value;
+    }
+
     get src() {
         return this.value;
     }
@@ -139,6 +150,7 @@ const PodiumAssetJs = class PodiumAssetJs {
             async: toUndefined(this.async),
             defer: toUndefined(this.defer),
             type: this.type,
+            data: this.data,
         };
     }
 

--- a/lib/html-utils.js
+++ b/lib/html-utils.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const notEmpty = value => {
+const notEmpty = (value) => {
     if (value === false) return value;
     if (value === undefined) return false;
     if (value === null) return false;
@@ -8,7 +8,7 @@ const notEmpty = value => {
     return false;
 };
 
-const buildScriptElement = obj => {
+const buildScriptElement = (obj) => {
     const args = [];
     args.push(`src="${obj.value}"`);
 
@@ -41,10 +41,16 @@ const buildScriptElement = obj => {
         args.push('defer');
     }
 
+    if (notEmpty(obj.data)) {
+        Object.entries(obj.data).forEach(([key, value]) => {
+            args.push(`data-${key}="${value}"`);
+        });
+    }
+
     return `<script ${args.join(' ')}></script>`;
 };
 
-const buildLinkElement = obj => {
+const buildLinkElement = (obj) => {
     const args = [];
     args.push(`href="${obj.value}"`);
 


### PR DESCRIPTION
Hi, we are trying to use Podium together with a "part" system. We have an Express server that loads React components dynamically , and render them server side. And then we want to serve the parts as Podlets.

But when we hydrate the components on the clientside, we need to know which hydration code that is for that specific component. And what we have done is that we id the scripts with a data attribute tag, and then we mark the props inline with the id from the script.

So we need to be able to add a data attribute to the script tags :-)

Please let me know if there is another way I could achieve this.

Thank you for your help, and for a cool tool!