### PR TITLE
fix: make 'data' property into an Array of key value objects

### DIFF
--- a/__tests__/asset-js.js
+++ b/__tests__/asset-js.js
@@ -29,7 +29,7 @@ test('Js() - no arguments given - should construct object with default values', 
     expect(obj.value).toEqual('/foo');
     expect(obj.type).toEqual('default');
     expect(obj.src).toEqual('/foo');
-    expect(obj.data).toEqual(undefined);
+    expect(obj.data).toEqual([]);
 });
 
 test('Js() - no arguments given - should construct JSON with default values', () => {
@@ -279,20 +279,32 @@ test('Js() - set "data" - should construct object as expected', () => {
         value: '/foo',
     });
 
-    obj.data = { foo: 'bar' };
+    obj.data = [{ 
+        key: 'foo',
+        value: 'bar'     
+    }];
 
-    expect(obj.data).toEqual({ foo: 'bar' });
+    expect(obj.data).toEqual([{ 
+        key: 'foo',
+        value: 'bar'     
+    }]);
     expect(obj.toHTML()).toEqual('<script src="/foo" data-foo="bar"></script>');
 
     const json = JSON.parse(JSON.stringify(obj));
     expect(json).toEqual({
         value: '/foo',
-        data: { foo: 'bar' },
+        data: [{ 
+            key: 'foo',
+            value: 'bar'     
+        }],
         type: 'default',
     });
 
     const repl = new Js(json);
-    expect(repl.data).toEqual({ foo: 'bar' });
+    expect(repl.data).toEqual([{ 
+        key: 'foo',
+        value: 'bar'     
+    }]);
 });
 
 test('Js() - set "value" - should throw', () => {

--- a/__tests__/html-utils.js
+++ b/__tests__/html-utils.js
@@ -277,7 +277,10 @@ test('.buildScriptElement() - "async" property is "true" - should appended "asyn
 test('.buildScriptElement() - "data" property has a value - should appended "data" attribute to element', () => {
     const obj = new AssetJs({
         value: '/foo',
-        data: { foo: 'bar' },
+        data: [{ 
+            key: 'foo',
+            value: 'bar'     
+        }],
     });
     const result = utils.buildScriptElement(obj);
     expect(result).toEqual('<script src="/foo" data-foo="bar"></script>');

--- a/lib/asset-js.js
+++ b/lib/asset-js.js
@@ -20,6 +20,7 @@ const _type = Symbol('podium:asset:js:type');
 const _data = Symbol('podium:asset:js:data');
 
 const toUndefined = (value) => {
+    if (Array.isArray(value) && value.length === 0) return undefined;
     if (value === false) return undefined;
     if (value === '') return undefined;
     return value;
@@ -37,7 +38,7 @@ const PodiumAssetJs = class PodiumAssetJs {
         async = false,
         defer = false,
         type = 'default',
-        data = undefined,
+        data = [],
     } = {}) {
         if (validate.js(value).error)
             throw new Error(
@@ -150,7 +151,7 @@ const PodiumAssetJs = class PodiumAssetJs {
             async: toUndefined(this.async),
             defer: toUndefined(this.defer),
             type: this.type,
-            data: this.data,
+            data: toUndefined(this.data),
         };
     }
 

--- a/lib/html-utils.js
+++ b/lib/html-utils.js
@@ -41,14 +41,6 @@ const buildScriptElement = (obj) => {
         args.push('defer');
     }
 
-    /*
-    if (notEmpty(obj.data)) {
-        Object.entries(obj.data).forEach(([key, value]) => {
-            args.push(`data-${key}="${value}"`);
-        });
-    }
-    */
-
     if (Array.isArray(obj.data) && (obj.data !== 0)) {
         obj.data.forEach((item) => {
             args.push(`data-${item.key}="${item.value}"`);

--- a/lib/html-utils.js
+++ b/lib/html-utils.js
@@ -41,9 +41,17 @@ const buildScriptElement = (obj) => {
         args.push('defer');
     }
 
+    /*
     if (notEmpty(obj.data)) {
         Object.entries(obj.data).forEach(([key, value]) => {
             args.push(`data-${key}="${value}"`);
+        });
+    }
+    */
+
+    if (Array.isArray(obj.data) && (obj.data !== 0)) {
+        obj.data.forEach((item) => {
+            args.push(`data-${item.key}="${item.value}"`);
         });
     }
 

--- a/lib/html-utils.js
+++ b/lib/html-utils.js
@@ -41,7 +41,7 @@ const buildScriptElement = (obj) => {
         args.push('defer');
     }
 
-    if (Array.isArray(obj.data) && (obj.data !== 0)) {
+    if (Array.isArray(obj.data) && (obj.data.lenght !== 0)) {
         obj.data.forEach((item) => {
             args.push(`data-${item.key}="${item.value}"`);
         });


### PR DESCRIPTION
In #58 data attributes was introduced as a property one can set for a javascript resoirce. In the original PR this sets the data attributes as an object in the manifest like so:

```js
js : {
    data_1: 'foo',
    data_2: 'bar'
}
```

This is not super optimal when parsing or creating the manifest from other languages than javascript. This PR changes this behaviour to be an Array of objects with key / value properties:

```js
js :[
    { key: 'data_1', value: 'foo' },
    { key: 'data_2', value: 'bar' },
]
```
This will btw be smoothed over in the @podium/podlet API so one can set an object instead of an array objects:

```js
podlet.js({
    type: 'module',
    value: '/some.js',
    data: {
        data_1: 'foo',
        data_2: 'bar'
    }
})
```