### PR TITLE
feat: support data attributes on javascript assets

### DIFF
--- a/__tests__/asset-js.js
+++ b/__tests__/asset-js.js
@@ -29,7 +29,7 @@ test('Js() - no arguments given - should construct object with default values', 
     expect(obj.value).toEqual('/foo');
     expect(obj.type).toEqual('default');
     expect(obj.src).toEqual('/foo');
-    expect(obj.data).toEqual(undefined);
+    expect(obj.data).toEqual([]);
 });
 
 test('Js() - no arguments given - should construct JSON with default values', () => {
@@ -279,20 +279,32 @@ test('Js() - set "data" - should construct object as expected', () => {
         value: '/foo',
     });
 
-    obj.data = { foo: 'bar' };
+    obj.data = [{ 
+        key: 'foo',
+        value: 'bar'     
+    }];
 
-    expect(obj.data).toEqual({ foo: 'bar' });
+    expect(obj.data).toEqual([{ 
+        key: 'foo',
+        value: 'bar'     
+    }]);
     expect(obj.toHTML()).toEqual('<script src="/foo" data-foo="bar"></script>');
 
     const json = JSON.parse(JSON.stringify(obj));
     expect(json).toEqual({
         value: '/foo',
-        data: { foo: 'bar' },
+        data: [{ 
+            key: 'foo',
+            value: 'bar'     
+        }],
         type: 'default',
     });
 
     const repl = new Js(json);
-    expect(repl.data).toEqual({ foo: 'bar' });
+    expect(repl.data).toEqual([{ 
+        key: 'foo',
+        value: 'bar'     
+    }]);
 });
 
 test('Js() - set "value" - should throw', () => {

--- a/__tests__/asset-js.js
+++ b/__tests__/asset-js.js
@@ -29,6 +29,7 @@ test('Js() - no arguments given - should construct object with default values', 
     expect(obj.value).toEqual('/foo');
     expect(obj.type).toEqual('default');
     expect(obj.src).toEqual('/foo');
+    expect(obj.data).toEqual(undefined);
 });
 
 test('Js() - no arguments given - should construct JSON with default values', () => {
@@ -271,6 +272,27 @@ test('Js() - set "type" - should construct object as expected', () => {
 
     const repl = new Js(json);
     expect(repl.type).toEqual('esm');
+});
+
+test('Js() - set "data" - should construct object as expected', () => {
+    const obj = new Js({
+        value: '/foo',
+    });
+
+    obj.data = { foo: 'bar' };
+
+    expect(obj.data).toEqual({ foo: 'bar' });
+    expect(obj.toHTML()).toEqual('<script src="/foo" data-foo="bar"></script>');
+
+    const json = JSON.parse(JSON.stringify(obj));
+    expect(json).toEqual({
+        value: '/foo',
+        data: { foo: 'bar' },
+        type: 'default',
+    });
+
+    const repl = new Js(json);
+    expect(repl.data).toEqual({ foo: 'bar' });
 });
 
 test('Js() - set "value" - should throw', () => {

--- a/__tests__/html-utils.js
+++ b/__tests__/html-utils.js
@@ -277,7 +277,10 @@ test('.buildScriptElement() - "async" property is "true" - should appended "asyn
 test('.buildScriptElement() - "data" property has a value - should appended "data" attribute to element', () => {
     const obj = new AssetJs({
         value: '/foo',
-        data: { foo: 'bar' },
+        data: [{ 
+            key: 'foo',
+            value: 'bar'     
+        }],
     });
     const result = utils.buildScriptElement(obj);
     expect(result).toEqual('<script src="/foo" data-foo="bar"></script>');

--- a/__tests__/html-utils.js
+++ b/__tests__/html-utils.js
@@ -274,6 +274,15 @@ test('.buildScriptElement() - "async" property is "true" - should appended "asyn
     expect(result).toEqual('<script src="/foo" async></script>');
 });
 
+test('.buildScriptElement() - "data" property has a value - should appended "data" attribute to element', () => {
+    const obj = new AssetJs({
+        value: '/foo',
+        data: { foo: 'bar' },
+    });
+    const result = utils.buildScriptElement(obj);
+    expect(result).toEqual('<script src="/foo" data-foo="bar"></script>');
+});
+
 test('.buildScriptElement() - "defer" property is "true" - should appended "defer" attribute to element', () => {
     const obj = new AssetJs({
         value: '/foo',

--- a/lib/asset-js.js
+++ b/lib/asset-js.js
@@ -17,8 +17,9 @@ const _value = Symbol('podium:asset:js:value');
 const _async = Symbol('podium:asset:js:async');
 const _defer = Symbol('podium:asset:js:defer');
 const _type = Symbol('podium:asset:js:type');
+const _data = Symbol('podium:asset:js:data');
 
-const toUndefined = value => {
+const toUndefined = (value) => {
     if (value === false) return undefined;
     if (value === '') return undefined;
     return value;
@@ -36,6 +37,7 @@ const PodiumAssetJs = class PodiumAssetJs {
         async = false,
         defer = false,
         type = 'default',
+        data = undefined,
     } = {}) {
         if (validate.js(value).error)
             throw new Error(
@@ -53,6 +55,7 @@ const PodiumAssetJs = class PodiumAssetJs {
         this[_async] = async;
         this[_defer] = defer;
         this[_type] = type;
+        this[_data] = data;
     }
 
     get referrerpolicy() {
@@ -121,6 +124,14 @@ const PodiumAssetJs = class PodiumAssetJs {
         this[_type] = value;
     }
 
+    get data() {
+        return this[_data];
+    }
+
+    set data(value) {
+        this[_data] = value;
+    }
+
     get src() {
         return this.value;
     }
@@ -139,6 +150,7 @@ const PodiumAssetJs = class PodiumAssetJs {
             async: toUndefined(this.async),
             defer: toUndefined(this.defer),
             type: this.type,
+            data: this.data,
         };
     }
 

--- a/lib/asset-js.js
+++ b/lib/asset-js.js
@@ -20,6 +20,7 @@ const _type = Symbol('podium:asset:js:type');
 const _data = Symbol('podium:asset:js:data');
 
 const toUndefined = (value) => {
+    if (Array.isArray(value) && value.length === 0) return undefined;
     if (value === false) return undefined;
     if (value === '') return undefined;
     return value;
@@ -37,7 +38,7 @@ const PodiumAssetJs = class PodiumAssetJs {
         async = false,
         defer = false,
         type = 'default',
-        data = undefined,
+        data = [],
     } = {}) {
         if (validate.js(value).error)
             throw new Error(
@@ -150,7 +151,7 @@ const PodiumAssetJs = class PodiumAssetJs {
             async: toUndefined(this.async),
             defer: toUndefined(this.defer),
             type: this.type,
-            data: this.data,
+            data: toUndefined(this.data),
         };
     }
 

--- a/lib/html-utils.js
+++ b/lib/html-utils.js
@@ -41,9 +41,9 @@ const buildScriptElement = (obj) => {
         args.push('defer');
     }
 
-    if (notEmpty(obj.data)) {
-        Object.entries(obj.data).forEach(([key, value]) => {
-            args.push(`data-${key}="${value}"`);
+    if (Array.isArray(obj.data) && (obj.data.lenght !== 0)) {
+        obj.data.forEach((item) => {
+            args.push(`data-${item.key}="${item.value}"`);
         });
     }
 

--- a/lib/html-utils.js
+++ b/lib/html-utils.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const notEmpty = value => {
+const notEmpty = (value) => {
     if (value === false) return value;
     if (value === undefined) return false;
     if (value === null) return false;
@@ -8,7 +8,7 @@ const notEmpty = value => {
     return false;
 };
 
-const buildScriptElement = obj => {
+const buildScriptElement = (obj) => {
     const args = [];
     args.push(`src="${obj.value}"`);
 
@@ -41,10 +41,16 @@ const buildScriptElement = obj => {
         args.push('defer');
     }
 
+    if (notEmpty(obj.data)) {
+        Object.entries(obj.data).forEach(([key, value]) => {
+            args.push(`data-${key}="${value}"`);
+        });
+    }
+
     return `<script ${args.join(' ')}></script>`;
 };
 
-const buildLinkElement = obj => {
+const buildLinkElement = (obj) => {
     const args = [];
     args.push(`href="${obj.value}"`);
 

--- a/lib/html-utils.js
+++ b/lib/html-utils.js
@@ -41,7 +41,7 @@ const buildScriptElement = (obj) => {
         args.push('defer');
     }
 
-    if (Array.isArray(obj.data) && (obj.data.lenght !== 0)) {
+    if (Array.isArray(obj.data) && (obj.data.length !== 0)) {
         obj.data.forEach((item) => {
             args.push(`data-${item.key}="${item.value}"`);
         });


### PR DESCRIPTION
This makes it possible to set data attributes on javascript assets. Iow; the manifest will contain a new `data` property which takes an array of key / value objects like so:

```js
{
    value: '/foo.js',
    data: [{ 
        key: 'foo',
        value: 'bar'     
    }],
}
```
This can then be used to build data attributes on the script tags in the html template:

```html
<script src="/foo.js" data-foo="bar"></script>
```