### PR TITLE
fix: Added type definition for the data attribute for AssetJS.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,6 +25,7 @@ export interface AssetJs extends PodiumAsset {
     async?: Pick<HTMLScriptElement, 'async'>;
     defer?: Pick<HTMLScriptElement, 'defer'>;
     type?: Pick<HTMLScriptElement, 'type'>;
+    data?: DOMStringMap;
 }
 
 export class HttpIncoming<T = { [key: string]: unknown }> {
@@ -52,5 +53,14 @@ export class HttpIncoming<T = { [key: string]: unknown }> {
 
     js: Array<AssetJs>;
 
-    toJSON(): { development: boolean, context: any, params: T, proxy: boolean, name: string; url: URL, css: Array<AssetCss>, js: Array<AssetJs> };
+    toJSON(): {
+        development: boolean;
+        context: any;
+        params: T;
+        proxy: boolean;
+        name: string;
+        url: URL;
+        css: Array<AssetCss>;
+        js: Array<AssetJs>;
+    };
 }


### PR DESCRIPTION
Forgot to add a type definition for the data attribute on the AssetJS in the [#58 ](https://github.com/podium-lib/utils/pull/58)

Now Typescript will not complain on this:
```typescript
podlet.js({
          value: '/foo.js',
          data: { foo: 'bar' }
})
```
Which will end up as a script element like this:
```html
<script src="/foo.js" data-foo="bar"></script>
```