### PR TITLE
feat(relative-uri)

### DIFF
--- a/__tests__/utils.js
+++ b/__tests__/utils.js
@@ -265,6 +265,12 @@ test('.uriIsRelative() - "uri" is absolute - should return "false"', () => {
     );
 });
 
+test('.uriIsRelative() - "uri" is absolute without schema - should return "false"', () => {
+    expect(utils.uriIsRelative('//localhost:7000/manifest.json')).toBe(
+        false,
+    );
+});
+
 /**
  * .uriRelativeToAbsolute()
  */

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -98,7 +98,7 @@ const uriBuilder = (input = '', base = '', extra = '') => {
  * @returns {Boolean}
  */
 
-const uriIsRelative = uri => uri.substr(0, 4) !== 'http';
+const uriIsRelative = uri => uri.substr(0, 4) !== 'http' && uri.substr(0, 2) !== '//';
 
 /**
  * Check if a URI is absolute or relative and if relative compose an


### PR DESCRIPTION
 added support to absolute uri without schema //, for example:

`//cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.1/js/all.min.js`
