### PR TITLE
fix: Simplify js and css value validation

### DIFF
--- a/__tests__/asset-css.js
+++ b/__tests__/asset-css.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { validate } = require('@podium/schemas');
 const Css = require('../lib/asset-css');
 
 test('Css() - object tag - should be PodiumAssetCss', () => {
@@ -341,4 +342,9 @@ test('Css() - set "href" - should throw', () => {
     expect(() => {
         obj.href = '/bar';
     }).toThrowError('Cannot set read-only property.');
+});
+
+test('Css() - validate object against schema - should validate', () => {
+    const obj = new Css({ value: '/foo' });
+    expect(validate.css([obj]).error).toEqual(false);
 });

--- a/__tests__/asset-js.js
+++ b/__tests__/asset-js.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { validate } = require('@podium/schemas');
 const Js = require('../lib/asset-js');
 
 test('Js() - object tag - should be PodiumAssetJs', () => {
@@ -324,5 +325,11 @@ test('Js() - set "src" - should throw', () => {
     });
     expect(() => {
         obj.src = '/bar';
+        console.log('promp')
     }).toThrowError('Cannot set read-only property.');
+});
+
+test('Js() - validate object against schema - should validate', () => {
+    const obj = new Js({ value: '/foo' });
+    expect(validate.js([obj]).error).toEqual(false);
 });

--- a/__tests__/asset-js.js
+++ b/__tests__/asset-js.js
@@ -325,7 +325,6 @@ test('Js() - set "src" - should throw', () => {
     });
     expect(() => {
         obj.src = '/bar';
-        console.log('promp')
     }).toThrowError('Cannot set read-only property.');
 });
 

--- a/lib/asset-css.js
+++ b/lib/asset-css.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { validate } = require('@podium/schemas');
 const { uriIsRelative, pathnameBuilder } = require('./utils');
 const { buildLinkElement } = require('./html-utils');
 
@@ -39,7 +38,7 @@ const PodiumAssetCss = class PodiumAssetCss {
         rel = 'stylesheet',
         as = '',
     } = {}) {
-        if (validate.css(value).error)
+        if (!toUndefined(value))
             throw new Error(
                 `Value for argument variable "value", "${value}", is not valid`,
             );

--- a/lib/asset-js.js
+++ b/lib/asset-js.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { validate } = require('@podium/schemas');
 const { uriIsRelative, pathnameBuilder } = require('./utils');
 const { buildScriptElement } = require('./html-utils');
 
@@ -40,11 +39,11 @@ const PodiumAssetJs = class PodiumAssetJs {
         type = 'default',
         data = [],
     } = {}) {
-        if (validate.js(value).error)
+        if (!toUndefined(value))
             throw new Error(
                 `Value for argument variable "value", "${value}", is not valid`,
             );
-
+        
         this[_pathname] = pathname;
         this[_prefix] = prefix;
         this[_value] = value;

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
         "@semantic-release/npm": "7.0.5",
         "@semantic-release/release-notes-generator": "9.0.1",
         "semantic-release": "17.1.1",
+        "@podium/schemas": "5.0.0-next.1",
         "benchmark": "2.1.4",
         "eslint": "7.3.1",
         "eslint-config-airbnb-base": "14.2.0",
@@ -67,7 +68,6 @@
         "prettier": "2.0.2"
     },
     "dependencies": {
-        "@podium/schemas": "4.0.2",
         "original-url": "1.2.3",
         "camelcase": "6.0.0"
     }


### PR DESCRIPTION
It does not really make any sense using the json schema to validate the `value` argument of a JS and CSS object. The schema is intended to validate the whole object and not just one single value. Due to this the validation of the `value` argument of a JS and CSS object is simplified.

The schema is updated to use version 5.0.0-next.1 and tests to validate a JS and CSS object with the schema is added.