### PR TITLE
feat: Use ES private properties instead of Symbols for privacy

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,12 +1,13 @@
 {
-    "env": {
-        "node": true
-    },
     "extends": ["airbnb-base", "prettier"],
     "plugins": ["prettier"],
-    "root": true,
+    "parser": "babel-eslint",
+    "parserOptions": {
+        "ecmaVersion": 11,
+        "sourceType": "module"
+    },
     "rules": {
-        "no-underscore-dangle": [0],
+        "lines-between-class-members": [0],
         "class-methods-use-this": [0],
         "strict": [0, "global"]
     }

--- a/lib/asset-css.js
+++ b/lib/asset-css.js
@@ -3,20 +3,10 @@
 const { uriIsRelative, pathnameBuilder } = require('./utils');
 const { buildLinkElement } = require('./html-utils');
 
+const inspect = Symbol.for('nodejs.util.inspect.custom');
+
 // Ref: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link
 // NOTE: Only includes attributes used for loading CSS
-
-const _crossorigin = Symbol('podium:asset:css:crossorigin');
-const _pathname = Symbol('podium:asset:css:pathname');
-const _disabled = Symbol('podium:asset:css:disabled');
-const _hreflang = Symbol('podium:asset:css:hreflang');
-const _prefix = Symbol('podium:asset:css:prefix');
-const _title = Symbol('podium:asset:css:title');
-const _value = Symbol('podium:asset:css:value');
-const _media = Symbol('podium:asset:css:media');
-const _type = Symbol('podium:asset:css:type');
-const _rel = Symbol('podium:asset:css:rel');
-const _as = Symbol('podium:asset:css:as');
 
 const toUndefined = value => {
     if (value === false) return undefined;
@@ -25,6 +15,17 @@ const toUndefined = value => {
 };
 
 const PodiumAssetCss = class PodiumAssetCss {
+    #crossorigin;
+    #pathname;
+    #disabled;
+    #hreflang;
+    #prefix;
+    #title;
+    #value;
+    #media;
+    #type;
+    #rel;
+    #as;
     constructor({
         crossorigin = undefined,
         pathname = '',
@@ -43,55 +44,55 @@ const PodiumAssetCss = class PodiumAssetCss {
                 `Value for argument variable "value", "${value}", is not valid`,
             );
 
-        this[_pathname] = pathname;
-        this[_prefix] = prefix;
-        this[_value] = value;
+        this.#pathname = pathname;
+        this.#prefix = prefix;
+        this.#value = value;
 
-        this[_crossorigin] = crossorigin;
-        this[_disabled] = disabled;
-        this[_hreflang] = hreflang;
-        this[_title] = title;
-        this[_media] = media;
-        this[_type] = type;
-        this[_rel] = rel;
-        this[_as] = as;
+        this.#crossorigin = crossorigin;
+        this.#disabled = disabled;
+        this.#hreflang = hreflang;
+        this.#title = title;
+        this.#media = media;
+        this.#type = type;
+        this.#rel = rel;
+        this.#as = as;
     }
 
     get crossorigin() {
-        return this[_crossorigin];
+        return this.#crossorigin;
     }
 
     set crossorigin(value) {
-        this[_crossorigin] = value;
+        this.#crossorigin = value;
     }
 
     get disabled() {
-        return this[_disabled];
+        return this.#disabled;
     }
 
     set disabled(value) {
-        this[_disabled] = value;
+        this.#disabled = value;
     }
 
     get hreflang() {
-        return this[_hreflang];
+        return this.#hreflang;
     }
 
     set hreflang(value) {
-        this[_hreflang] = value;
+        this.#hreflang = value;
     }
 
     get title() {
-        return this[_title];
+        return this.#title;
     }
 
     set title(value) {
-        this[_title] = value;
+        this.#title = value;
     }
 
     get value() {
-        const pathname = this[_prefix] ? this[_pathname] : '';
-        const value = this[_value];
+        const pathname = this.#prefix ? this.#pathname : '';
+        const value = this.#value;
         return uriIsRelative(value) ? pathnameBuilder(pathname, value) : value;
     }
 
@@ -100,19 +101,19 @@ const PodiumAssetCss = class PodiumAssetCss {
     }
 
     get media() {
-        return this[_media];
+        return this.#media;
     }
 
     set media(value) {
-        this[_media] = value;
+        this.#media = value;
     }
 
     get type() {
-        return this[_type];
+        return this.#type;
     }
 
     set type(value) {
-        this[_type] = value;
+        this.#type = value;
     }
 
     get href() {
@@ -124,19 +125,19 @@ const PodiumAssetCss = class PodiumAssetCss {
     }
 
     get rel() {
-        return this[_rel];
+        return this.#rel;
     }
 
     set rel(value) {
-        this[_rel] = value;
+        this.#rel = value;
     }
 
     get as() {
-        return this[_as];
+        return this.#as;
     }
 
     set as(value) {
-        this[_as] = value;
+        this.#as = value;
     }
 
     toJSON() {
@@ -145,7 +146,7 @@ const PodiumAssetCss = class PodiumAssetCss {
             disabled: toUndefined(this.disabled),
             hreflang: toUndefined(this.hreflang),
             title: toUndefined(this.title),
-            value: this[_value],
+            value: this.#value,
             media: toUndefined(this.media),
             type: this.type,
             rel: this.rel,
@@ -155,6 +156,20 @@ const PodiumAssetCss = class PodiumAssetCss {
 
     toHTML() {
         return buildLinkElement(this);
+    }
+
+    [inspect]() {
+        return {
+            crossorigin: this.crossorigin,
+            disabled: this.disabled,
+            hreflang: this.hreflang,
+            title: this.title,
+            value: this.value,
+            media: this.media,
+            type: this.type,
+            rel: this.rel,
+            as: this.as,
+        };
     }
 
     get [Symbol.toStringTag]() {

--- a/lib/asset-js.js
+++ b/lib/asset-js.js
@@ -3,20 +3,10 @@
 const { uriIsRelative, pathnameBuilder } = require('./utils');
 const { buildScriptElement } = require('./html-utils');
 
+const inspect = Symbol.for('nodejs.util.inspect.custom');
+
 // Ref: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script
 // NOTE: "nonce" is deliberately left out since we do not support inline scripts
-
-const _referrerpolicy = Symbol('podium:asset:js:referrerpolicy');
-const _crossorigin = Symbol('podium:asset:js:crossorigin');
-const _integrity = Symbol('podium:asset:js:integrity');
-const _pathname = Symbol('podium:asset:js:pathname');
-const _nomodule = Symbol('podium:asset:js:nomodule');
-const _prefix = Symbol('podium:asset:js:prefix');
-const _value = Symbol('podium:asset:js:value');
-const _async = Symbol('podium:asset:js:async');
-const _defer = Symbol('podium:asset:js:defer');
-const _type = Symbol('podium:asset:js:type');
-const _data = Symbol('podium:asset:js:data');
 
 const toUndefined = (value) => {
     if (Array.isArray(value) && value.length === 0) return undefined;
@@ -26,6 +16,17 @@ const toUndefined = (value) => {
 };
 
 const PodiumAssetJs = class PodiumAssetJs {
+    #referrerpolicy;
+    #crossorigin;
+    #integrity;
+    #pathname;
+    #nomodule;
+    #prefix;
+    #value;
+    #async;
+    #defer;
+    #type;
+    #data;
     constructor({
         referrerpolicy = '',
         crossorigin = undefined,
@@ -44,55 +45,55 @@ const PodiumAssetJs = class PodiumAssetJs {
                 `Value for argument variable "value", "${value}", is not valid`,
             );
         
-        this[_pathname] = pathname;
-        this[_prefix] = prefix;
-        this[_value] = value;
+        this.#pathname = pathname;
+        this.#prefix = prefix;
+        this.#value = value;
 
-        this[_referrerpolicy] = referrerpolicy;
-        this[_crossorigin] = crossorigin;
-        this[_integrity] = integrity;
-        this[_nomodule] = nomodule;
-        this[_async] = async;
-        this[_defer] = defer;
-        this[_type] = type;
-        this[_data] = data;
+        this.#referrerpolicy = referrerpolicy;
+        this.#crossorigin = crossorigin;
+        this.#integrity = integrity;
+        this.#nomodule = nomodule;
+        this.#async = async;
+        this.#defer = defer;
+        this.#type = type;
+        this.#data = data;
     }
 
     get referrerpolicy() {
-        return this[_referrerpolicy];
+        return this.#referrerpolicy;
     }
 
     set referrerpolicy(value) {
-        this[_referrerpolicy] = value;
+        this.#referrerpolicy = value;
     }
 
     get crossorigin() {
-        return this[_crossorigin];
+        return this.#crossorigin;
     }
 
     set crossorigin(value) {
-        this[_crossorigin] = value;
+        this.#crossorigin = value;
     }
 
     get integrity() {
-        return this[_integrity];
+        return this.#integrity;
     }
 
     set integrity(value) {
-        this[_integrity] = value;
+        this.#integrity = value;
     }
 
     get nomodule() {
-        return this[_nomodule];
+        return this.#nomodule;
     }
 
     set nomodule(value) {
-        this[_nomodule] = value;
+        this.#nomodule = value;
     }
 
     get value() {
-        const pathname = this[_prefix] ? this[_pathname] : '';
-        const value = this[_value];
+        const pathname = this.#prefix ? this.#pathname : '';
+        const value = this.#value;
         return uriIsRelative(value) ? pathnameBuilder(pathname, value) : value;
     }
 
@@ -101,35 +102,35 @@ const PodiumAssetJs = class PodiumAssetJs {
     }
 
     get async() {
-        return this[_async];
+        return this.#async;
     }
 
     set async(value) {
-        this[_async] = value;
+        this.#async = value;
     }
 
     get defer() {
-        return this[_defer];
+        return this.#defer;
     }
 
     set defer(value) {
-        this[_defer] = value;
+        this.#defer = value;
     }
 
     get type() {
-        return this[_type];
+        return this.#type;
     }
 
     set type(value) {
-        this[_type] = value;
+        this.#type = value;
     }
 
     get data() {
-        return this[_data];
+        return this.#data;
     }
 
     set data(value) {
-        this[_data] = value;
+        this.#data = value;
     }
 
     get src() {
@@ -146,7 +147,7 @@ const PodiumAssetJs = class PodiumAssetJs {
             crossorigin: this.crossorigin,
             integrity: toUndefined(this.integrity),
             nomodule: toUndefined(this.nomodule),
-            value: this[_value],
+            value: this.#value,
             async: toUndefined(this.async),
             defer: toUndefined(this.defer),
             type: this.type,
@@ -156,6 +157,20 @@ const PodiumAssetJs = class PodiumAssetJs {
 
     toHTML() {
         return buildScriptElement(this);
+    }
+
+    [inspect]() {
+        return {
+            referrerpolicy: this.referrerpolicy,
+            crossorigin: this.crossorigin,
+            integrity: this.integrity,
+            nomodule: this.nomodule,
+            value: this.value,
+            async: this.async,
+            defer: this.defer,
+            type: this.type,
+            data: this.data,
+        };
     }
 
     get [Symbol.toStringTag]() {

--- a/lib/http-incoming.js
+++ b/lib/http-incoming.js
@@ -3,17 +3,7 @@
 const originalUrl = require('original-url');
 const { URL } = require('url');
 
-const _development = Symbol('podium:httpincoming:development');
-const _response = Symbol('podium:httpincoming:response');
-const _request = Symbol('podium:httpincoming:request');
-const _context = Symbol('podium:httpincoming:context');
-const _params = Symbol('podium:httpincoming:params');
-const _proxy = Symbol('podium:httpincoming:proxy');
-const _view = Symbol('podium:httpincoming:view');
-const _name = Symbol('podium:httpincoming:name');
-const _url = Symbol('podium:httpincoming:url');
-const _css = Symbol('podium:httpincoming:css');
-const _js = Symbol('podium:httpincoming:js');
+const inspect = Symbol.for('nodejs.util.inspect.custom');
 
 const urlFromRequest = request => {
     try {
@@ -25,29 +15,39 @@ const urlFromRequest = request => {
 };
 
 const PodiumHttpIncoming = class PodiumHttpIncoming {
+    #development;
+    #response;
+    #request;
+    #context;
+    #params;
+    #proxy;
+    #name;
+    #view;
+    #url;
+    #css;
+    #js;
     constructor(request = {}, response = {}, params = {}) {
         const url = urlFromRequest(request);
+        this.#development = false;
+        this.#response = response;
+        this.#request = request;
+        this.#context = {};
+        this.#params = params;
+        this.#proxy = false;
+        this.#name = '';
+        this.#view = {};
+        this.#url = url;
+        this.#css = [];
+        this.#js = [];
 
-        // Private properties
-        this[_development] = false;
-        this[_response] = response;
-        this[_request] = request;
-        this[_context] = {};
-        this[_params] = params;
-        this[_proxy] = false;
-        this[_name] = '';
-        this[_view] = {};
-        this[_url] = url;
-        this[_css] = [];
-        this[_js] = [];
     }
 
     set development(value) {
-        this[_development] = value;
+        this.#development = value;
     }
 
     get development() {
-        return this[_development];
+        return this.#development;
     }
 
     set response(value) {
@@ -55,7 +55,7 @@ const PodiumHttpIncoming = class PodiumHttpIncoming {
     }
 
     get response() {
-        return this[_response];
+        return this.#response;
     }
 
     set request(value) {
@@ -63,15 +63,15 @@ const PodiumHttpIncoming = class PodiumHttpIncoming {
     }
 
     get request() {
-        return this[_request];
+        return this.#request;
     }
 
     set context(value) {
-        this[_context] = value;
+        this.#context = value;
     }
 
     get context() {
-        return this[_context];
+        return this.#context;
     }
 
     set podlets(value) {
@@ -80,13 +80,13 @@ const PodiumHttpIncoming = class PodiumHttpIncoming {
         podlets.forEach(podlet => {
             if (podlet.css) {
                 podlet.css.forEach(item => {
-                    this[_css].push(item);
+                    this.#css.push(item);
                 });
             }
 
             if (podlet.js) {
                 podlet.js.forEach(item => {
-                    this[_js].push(item);
+                    this.#js.push(item);
                 });
             }
         });
@@ -103,59 +103,59 @@ const PodiumHttpIncoming = class PodiumHttpIncoming {
     }
 
     get params() {
-        return this[_params];
+        return this.#params;
     }
 
     set proxy(value) {
-        this[_proxy] = value;
+        this.#proxy = value;
     }
 
     get proxy() {
-        return this[_proxy];
+        return this.#proxy;
     }
 
     set name(value) {
-        this[_name] = value;
+        this.#name = value;
     }
 
     get name() {
-        return this[_name];
+        return this.#name;
     }
 
     set view(value) {
-        this[_view] = value;
+        this.#view = value;
     }
 
     get view() {
-        return this[_view];
+        return this.#view;
     }
 
     set url(value) {
-        this[_url] = value;
+        this.#url = value;
     }
 
     get url() {
-        return this[_url];
+        return this.#url;
     }
 
     set css(value) {
         if (!Array.isArray(value))
             throw new Error(`Value for property ".css" must be an Array`);
-        this[_css] = value;
+        this.#css = value;
     }
 
     get css() {
-        return this[_css];
+        return this.#css;
     }
 
     set js(value) {
         if (!Array.isArray(value))
             throw new Error(`Value for property ".js" must be an Array`);
-        this[_js] = value;
+        this.#js = value;
     }
 
     get js() {
-        return this[_js];
+        return this.#js;
     }
 
     toJSON() {
@@ -164,14 +164,30 @@ const PodiumHttpIncoming = class PodiumHttpIncoming {
             context: this.context,
             params: this.params,
             proxy: this.proxy,
-            view: this.view,
             name: this.name,
+            view: this.view,
             url: this.url,
             css: this.css,
             js: this.js,
         };
     }
 
+    [inspect]() {
+        return {
+            development: this.development,
+            response: this.response,
+            request: this.request,
+            context: this.context,
+            params: this.params,
+            proxy: this.proxy,
+            name: this.name,
+            view: this.view,
+            url: this.url,
+            css: this.css,
+            js: this.js,
+        };
+    }
+    
     get [Symbol.toStringTag]() {
         return 'PodiumHttpIncoming';
     }

--- a/package.json
+++ b/package.json
@@ -44,11 +44,12 @@
         "semantic-release": "17.1.1",
         "@podium/schemas": "5.0.0-next.1",
         "benchmark": "2.1.4",
-        "eslint": "7.3.1",
+        "eslint": "7.5.0",
         "eslint-config-airbnb-base": "14.2.0",
         "eslint-config-prettier": "6.11.0",
         "eslint-plugin-import": "2.22.0",
         "eslint-plugin-prettier": "3.1.4",
+        "babel-eslint": "10.1.0",
         "prettier": "2.0.2",
         "tap": "14.10.8"
     },


### PR DESCRIPTION
BREAKING CHANGE: Due to dropping node 10.x support we use ES private properties instead of Symbols.

We've been using Symbols to define private properties in classes up
until now. This has the downside that they are not true private and in
later versions of node.js one would see these Symbols when inspecting
an object. What we want is proper private properties.

This PR does also add a pretty printer which outputs an object literal
or the object so when debugging one can see the getters and setters
of the object.

Example: printing a object with `console.log()` would previously print
the following:

```sh
PodiumHttpIncoming {
  [Symbol(podium:httpincoming:development)]: false,
  [Symbol(podium:httpincoming:response)]: {},
  [Symbol(podium:httpincoming:request)]: {},
  [Symbol(podium:httpincoming:context)]: {},
  [Symbol(podium:httpincoming:params)]: {},
  [Symbol(podium:httpincoming:proxy)]: false,
  [Symbol(podium:httpincoming:name)]: '',
  [Symbol(podium:httpincoming:view)]: {},
  [Symbol(podium:httpincoming:url)]: {},
  [Symbol(podium:httpincoming:css)]: [],
  [Symbol(podium:httpincoming:js)]: []
}
```

Now the following will be printed:

```sh
{
  development: false,
  response: {},
  request: {},
  context: {},
  params: {},
  proxy: false,
  name: '',
  view: {},
  url: {},
  css: [],
  js: []
}
```