### PR TITLE
fix: Remove original-url module

### DIFF
--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -2,8 +2,8 @@
 
 /* eslint no-unused-vars: "off", import/no-extraneous-dependencies: "off", no-console: "off" */
 
-const benchmark = require('benchmark');
-const HttpIncoming = require('../lib/http-incoming');
+import benchmark from 'benchmark';
+import HttpIncoming from '../lib/http-incoming.js';
 
 const suite = new benchmark.Suite();
 
@@ -19,6 +19,7 @@ const REQ = {
     headers: {
         host: 'localhost:3030',
     },
+    protocol: 'http:',
     hostname: 'localhost',
     url: '/some/path',
 };
@@ -33,10 +34,12 @@ const PARAMS = {
 
 add('new HttpIncoming() - No params', () => {
     const incoming = new HttpIncoming(REQ, RES);
+    const {url} = incoming;
 });
 
 add('new HttpIncoming() - With params', () => {
     const incoming = new HttpIncoming(REQ, RES, PARAMS);
+    const {url} = incoming;
 });
 
 suite

--- a/lib/http-incoming.js
+++ b/lib/http-incoming.js
@@ -1,15 +1,12 @@
-import originalUrl from 'original-url';
-import { URL } from 'url';
+import { URL } from 'node:url';
 
 const inspect = Symbol.for('nodejs.util.inspect.custom');
 
 const urlFromRequest = request => {
-    try {
-        const url = originalUrl(request);
-        return new URL(url.raw, `${url.protocol}//${request.headers.host}`);
-    } catch (err) {
-        return {};
-    }
+    const protocol = request?.protocol || 'http';
+    const host = request?.headers?.host || 'localhost';
+    const url = request?.url || '';
+    return new URL(url, `${protocol.replace(/:/, '')}://${host}`);
 };
 
 export default class HttpIncoming {
@@ -25,7 +22,6 @@ export default class HttpIncoming {
     #css;
     #js;
     constructor(request = {}, response = {}, params = {}) {
-        const url = urlFromRequest(request);
         this.#development = false;
         this.#response = response;
         this.#request = request;
@@ -34,7 +30,7 @@ export default class HttpIncoming {
         this.#proxy = false;
         this.#name = '';
         this.#view = {};
-        this.#url = url;
+        this.#url = undefined;
         this.#css = [];
         this.#js = [];
 
@@ -129,11 +125,12 @@ export default class HttpIncoming {
     }
 
     set url(value) {
-        this.#url = value;
+        this.#url = new URL(value);
     }
 
     get url() {
-        return this.#url;
+        if (this.#url) return this.#url;
+        return urlFromRequest(this.#request);;
     }
 
     set css(value) {
@@ -190,4 +187,3 @@ export default class HttpIncoming {
         return 'PodiumHttpIncoming';
     }
 };
-// export default HttpIncoming;

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
         "@podium/schemas": "5.0.0-next.5"
     },
     "dependencies": {
-        "camelcase": "6.3.0",
-        "original-url": "1.2.3"
+        "camelcase": "6.3.0"
     }
 }

--- a/tests/http-incoming.js
+++ b/tests/http-incoming.js
@@ -57,56 +57,6 @@ tap.test('PodiumHttpIncoming() - "request" argument given - should set parsed UR
     t.end();
 });
 
-tap.test('PodiumHttpIncoming() - has forwarded - should set ignore hostname and use host', (t) => {
-    const incoming = new HttpIncoming({
-        headers: {
-            host: 'localhost:3030',
-            forwarded: 'host=example.com; proto=https',
-        },
-        hostname: 'localhost',
-        url: '/some/path',
-    });
-    t.equal(incoming.url.hostname, 'localhost');
-    t.equal(incoming.url.host, 'localhost:3030');
-    t.equal(incoming.url.port, '3030');
-    t.equal(incoming.url.protocol, 'https:');
-    t.equal(incoming.url.pathname, '/some/path');
-    t.end();
-});
-
-tap.test('PodiumHttpIncoming() - forwarded https request - should set ".url.protocol" to https', (t) => {
-    const incoming = new HttpIncoming({
-        headers: {
-            host: 'localhost:3030',
-            'x-forwarded-proto': 'https',
-        },
-        hostname: 'localhost',
-        url: '/some/path',
-    });
-    t.equal(incoming.url.hostname, 'localhost');
-    t.equal(incoming.url.host, 'localhost:3030');
-    t.equal(incoming.url.port, '3030');
-    t.equal(incoming.url.protocol, 'https:');
-    t.equal(incoming.url.pathname, '/some/path');
-    t.end();
-});
-
-tap.test('PodiumHttpIncoming() - request has ".originalUrl" instead of ".url" - should set value of ".originalUrl" as ".url.pathname"', (t) => {
-    const incoming = new HttpIncoming({
-        headers: {
-            host: 'localhost:3030',
-        },
-        hostname: 'localhost',
-        originalUrl: '/some/path',
-    });
-    t.equal(incoming.url.hostname, 'localhost');
-    t.equal(incoming.url.host, 'localhost:3030');
-    t.equal(incoming.url.port, '3030');
-    t.equal(incoming.url.protocol, 'http:');
-    t.equal(incoming.url.pathname, '/some/path');
-    t.end();
-});
-
 tap.test('PodiumHttpIncoming() - "response" argument given - should store request on ".response"', (t) => {
     const incoming = new HttpIncoming(ADVANCED_REQ, SIMPLE_RES);
     t.same(incoming.response, SIMPLE_RES);
@@ -148,8 +98,8 @@ tap.test('PodiumHttpIncoming.params - set value', (t) => {
 
 tap.test('PodiumHttpIncoming.url - set value - should set value', (t) => {
     const incoming = new HttpIncoming(ADVANCED_REQ, SIMPLE_RES);
-    incoming.url = 'foo';
-    t.equal(incoming.url, 'foo');
+    incoming.url = 'http://localhost:8080/foo';
+    t.equal(incoming.url.href, 'http://localhost:8080/foo');
     t.end();
 });
 


### PR DESCRIPTION
This remove the [original-url](https://www.npmjs.com/package/original-url) from `http-incoming`. We've been using this module to do out own parsing to find the original URL of a request but this is in reality double work. This is also handled by all http frameworks so we should instead set the original URL on `http-incoming` each framework provide instead of doing this parsing our self.

The [original-url](https://www.npmjs.com/package/original-url) seems to [not be very maintained](https://github.com/watson/original-url/pull/10) and is causing some deprecation warnings in ex Fastify: https://github.com/podium-lib/issues/issues/52.