### PR TITLE
fix: add missing functions to type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -38,6 +38,8 @@ export class AssetCss
     readonly value: string;
     data?: Array<{ key: string; value: string }>;
     toHTML(): string;
+    toJSON(): Record<string, any>;
+    toJsxAttributes(): Record<string, any>;
 }
 
 export class AssetJs
@@ -68,6 +70,8 @@ export class AssetJs
     readonly value: string;
     data?: Array<{ key: string; value: string }>;
     toHTML(): string;
+    toJSON(): Record<string, any>;
+    toJsxAttributes(): Record<string, any>;
 }
 
 export class HttpIncoming<T = { [key: string]: unknown }> {


### PR DESCRIPTION
Adds `toJSON` and `toJsxAttributes` to `AssetJs` and `AssetCss`