### PR TITLE
feat: add strategy and scope fields to AssetCss and AssetJs classes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
   - name: Setup Node.js
     uses: actions/setup-node@v3
     with:
-      node-version: 16.x
+      node-version: 20.x
   - name: npm install
     run: |
       npm install
@@ -38,7 +38,7 @@ jobs:
   - name: Setup Node.js
     uses: actions/setup-node@v3
     with:
-      node-version: 16.x
+      node-version: 20.x
   - name: npm install
     run: |
       npm install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        node-version: [12.x, 14.x, 16.x, 17.x]
+        node-version: [12.x, 14.x, 16.x, 18.x, 20.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}

--- a/__tests__/__snapshots__/html-document.js.snap
+++ b/__tests__/__snapshots__/html-document.js.snap
@@ -10,13 +10,15 @@ exports[`.document() - arguments given - handles v4 js and css syntax 1`] = `
         <link href=\\"http://somecssurl1.com\\" type=\\"text/css\\">
         <link href=\\"http://somecssurl2.com\\" type=\\"text/css\\">
         <link href=\\"http://somecssurl3.com\\" type=\\"text/css\\">
-        <script src=\\"http://somejsurl1.com\\"></script>
-        <script src=\\"http://somejsurl2.com\\"></script>
-        <script src=\\"http://somejsurl3.com\\"></script>
+        
         <title></title>
         
     </head>
     <body>
+        
+        <script src=\\"http://somejsurl1.com\\"></script>
+        <script src=\\"http://somejsurl2.com\\"></script>
+        <script src=\\"http://somejsurl3.com\\"></script>
         
     </body>
 </html>"
@@ -30,12 +32,14 @@ exports[`.document() - arguments given - should render template using values giv
         <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1\\">
         <meta http-equiv=\\"X-UA-Compatible\\" content=\\"IE=Edge\\">
         <link href=\\"http://somecssurl.com\\">
-        <script src=\\"http://somejsurl.com\\"></script>
+        
         <title>this goes in the title tag</title>
         this goes in the head section
     </head>
     <body>
         this goes in the body section
+        <script src=\\"http://somejsurl.com\\"></script>
+        
     </body>
 </html>"
 `;
@@ -50,14 +54,36 @@ exports[`.document() - js "type" is "esm" - should set type to module on script 
         <link href=\\"http://somecssurl1.com\\" type=\\"text/css\\">
         <link href=\\"http://somecssurl2.com\\" type=\\"text/css\\">
         <link href=\\"http://somecssurl3.com\\" type=\\"text/css\\">
-        <script src=\\"http://somejsurl1.com\\" type=\\"module\\"></script>
-        <script src=\\"http://somejsurl2.com\\" type=\\"module\\"></script>
-        <script src=\\"http://somejsurl3.com\\" type=\\"module\\"></script>
+        
         <title></title>
         
     </head>
     <body>
         
+        <script src=\\"http://somejsurl1.com\\" type=\\"module\\"></script>
+        <script src=\\"http://somejsurl2.com\\" type=\\"module\\"></script>
+        <script src=\\"http://somejsurl3.com\\" type=\\"module\\"></script>
+        
+    </body>
+</html>"
+`;
+
+exports[`.document() - js "type" is "esm" - should set type to module on script tags 2`] = `
+"<!doctype html>
+<html lang=\\"en-US\\">
+    <head>
+        <meta charset=\\"utf-8\\">
+        <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1\\">
+        <meta http-equiv=\\"X-UA-Compatible\\" content=\\"IE=Edge\\">
+        <link href=\\"http://somecssurl1.com\\" type=\\"text/css\\">
+        <script src=\\"http://somejsurl2.com/before\\" type=\\"module\\"></script>
+        <title></title>
+        
+    </head>
+    <body>
+        
+        <script src=\\"http://somejsurl3.com/after\\" type=\\"module\\"></script>
+        <script type=\\"module\\">import(\\"http://somejsurl1.com/lazy\\")</script>
     </body>
 </html>"
 `;
@@ -75,6 +101,8 @@ exports[`.document() - no arguments given - should render template 1`] = `
         
     </head>
     <body>
+        
+        
         
     </body>
 </html>"

--- a/__tests__/asset-css.js
+++ b/__tests__/asset-css.js
@@ -351,3 +351,33 @@ test('Css() - .toReactAttrs()', () => {
         type: 'text/css',
     });
 });
+
+test('Css() - strategy is given - should set "lazy" strategy', () => {
+  const obj = new Css({ value: '/foo', strategy: "lazy" });
+  expect(obj.strategy).toEqual("lazy");
+});
+
+test('Css() - strategy is given - should set "beforeInteractive" strategy', () => {
+  const obj = new Css({ value: '/foo', strategy: "beforeInteractive" });
+  expect(obj.strategy).toEqual("beforeInteractive");
+});
+
+test('Css() - strategy is given - should set "afterInteractive" strategy', () => {
+  const obj = new Css({ value: '/foo', strategy: "afterInteractive" });
+  expect(obj.strategy).toEqual("afterInteractive");
+});
+
+test('Css() - scope is given - should set "all" scope', () => {
+  const obj = new Css({ value: '/foo', scope: "all" });
+  expect(obj.scope).toEqual("all");
+});
+
+test('Css() - scope is given - should set "content" scope', () => {
+  const obj = new Css({ value: '/foo', scope: "content" });
+  expect(obj.scope).toEqual("content");
+});
+
+test('Css() - scope is given - should set "fallback" scope', () => {
+  const obj = new Css({ value: '/foo', scope: "fallback" });
+  expect(obj.scope).toEqual("fallback");
+});

--- a/__tests__/asset-js.js
+++ b/__tests__/asset-js.js
@@ -331,3 +331,33 @@ test('Js() - .toReactAttrs()', () => {
     const obj = new Js({ value: '/foo' });
     expect(obj.toJsxAttributes()).toEqual({ src: '/foo' });
 });
+
+test('Js() - strategy is given - should set "lazy" strategy', () => {
+  const obj = new Js({ value: '/foo', strategy: "lazy" });
+  expect(obj.strategy).toEqual("lazy");
+});
+
+test('Js() - strategy is given - should set "beforeInteractive" strategy', () => {
+  const obj = new Js({ value: '/foo', strategy: "beforeInteractive" });
+  expect(obj.strategy).toEqual("beforeInteractive");
+});
+
+test('Js() - strategy is given - should set "afterInteractive" strategy', () => {
+  const obj = new Js({ value: '/foo', strategy: "afterInteractive" });
+  expect(obj.strategy).toEqual("afterInteractive");
+});
+
+test('Js() - scope is given - should set "all" scope', () => {
+  const obj = new Js({ value: '/foo', scope: "all" });
+  expect(obj.scope).toEqual("all");
+});
+
+test('Js() - scope is given - should set "content" scope', () => {
+  const obj = new Js({ value: '/foo', scope: "content" });
+  expect(obj.scope).toEqual("content");
+});
+
+test('Js() - scope is given - should set "fallback" scope', () => {
+  const obj = new Js({ value: '/foo', scope: "fallback" });
+  expect(obj.scope).toEqual("fallback");
+});

--- a/__tests__/html-document.js
+++ b/__tests__/html-document.js
@@ -73,3 +73,16 @@ test('.document() - js "type" is "esm" - should set type to module on script tag
     const result = document(incoming);
     expect(result).toMatchSnapshot();
 });
+
+test('.document() - js "type" is "esm" - should set type to module on script tags', () => {
+    const incoming = new HttpIncoming(SIMPLE_REQ, SIMPLE_RES);
+    incoming.css = [{ value: 'http://somecssurl1.com', type: 'text/css' }];
+    incoming.js = [
+        { value: 'http://somejsurl1.com/lazy', type: 'module', strategy: 'lazy' },
+        { value: 'http://somejsurl2.com/before', type: 'module', strategy: 'beforeInteractive' },
+        { value: 'http://somejsurl3.com/after', type: 'module', strategy: 'afterInteractive' },
+    ];
+
+    const result = document(incoming);
+    expect(result).toMatchSnapshot();
+});

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,6 +25,8 @@ export class AssetCss
         type?: string | false | null;
         value: string | false | null;
         data?: Array<{ key: string; value: string }>;
+        strategy?: "beforeInteractive" | "afterInteractive" | "lazy";
+        scope?: "content" | "fallback" | "all";
     });
 
     as: string;
@@ -37,6 +39,8 @@ export class AssetCss
     type: string;
     readonly value: string;
     data?: Array<{ key: string; value: string }>;
+    strategy?: "beforeInteractive" | "afterInteractive" | "lazy";
+    scope?: "content" | "fallback" | "all";
     toHTML(): string;
     toJSON(): Record<string, any>;
     toJsxAttributes(): Record<string, any>;
@@ -57,6 +61,8 @@ export class AssetJs
         defer?: boolean | null | '';
         value: string | null;
         data?: Array<{ key: string; value: string }>;
+        strategy?: "beforeInteractive" | "afterInteractive" | "lazy";
+        scope?: "content" | "fallback" | "all";
     });
 
     crossorigin: string | null;
@@ -69,6 +75,8 @@ export class AssetJs
     prefix?: boolean;
     readonly value: string;
     data?: Array<{ key: string; value: string }>;
+    strategy?: "beforeInteractive" | "afterInteractive" | "lazy";
+    scope?: "content" | "fallback" | "all";
     toHTML(): string;
     toJSON(): Record<string, any>;
     toJsxAttributes(): Record<string, any>;

--- a/lib/asset-css.js
+++ b/lib/asset-css.js
@@ -18,6 +18,8 @@ const _media = Symbol('podium:asset:css:media');
 const _type = Symbol('podium:asset:css:type');
 const _rel = Symbol('podium:asset:css:rel');
 const _as = Symbol('podium:asset:css:as');
+const _strategy = Symbol('podium:asset:css:strategy');
+const _scope = Symbol('podium:asset:css:scope');
 
 const toUndefined = value => {
     if (value === false) return undefined;
@@ -38,6 +40,8 @@ const PodiumAssetCss = class PodiumAssetCss {
         type = 'text/css',
         rel = 'stylesheet',
         as = '',
+        strategy = undefined,
+        scope = undefined,
     } = {}) {
         if (validate.css(value).error)
             throw new Error(
@@ -56,6 +60,8 @@ const PodiumAssetCss = class PodiumAssetCss {
         this[_type] = type;
         this[_rel] = rel;
         this[_as] = as;
+        this[_strategy] = strategy;
+        this[_scope] = scope;
     }
 
     get crossorigin() {
@@ -140,6 +146,22 @@ const PodiumAssetCss = class PodiumAssetCss {
         this[_as] = value;
     }
 
+    get strategy() {
+        return this[_strategy];
+    }
+
+    set strategy(value) {
+        this[_strategy] = value;
+    }
+
+    get scope() {
+        return this[_scope];
+    }
+
+    set scope(value) {
+        this[_scope] = value;
+    }
+
     toJSON() {
         return {
             crossorigin: toUndefined(this.crossorigin),
@@ -151,6 +173,8 @@ const PodiumAssetCss = class PodiumAssetCss {
             type: this.type,
             rel: this.rel,
             as: toUndefined(this.as),
+            strategy: toUndefined(this.strategy),
+            scope: toUndefined(this.scope)
         };
     }
 

--- a/lib/asset-js.js
+++ b/lib/asset-js.js
@@ -18,6 +18,8 @@ const _async = Symbol('podium:asset:js:async');
 const _defer = Symbol('podium:asset:js:defer');
 const _type = Symbol('podium:asset:js:type');
 const _data = Symbol('podium:asset:js:data');
+const _strategy = Symbol('podium:asset:js:strategy');
+const _scope = Symbol('podium:asset:js:scope');
 
 const toUndefined = (value) => {
     if (Array.isArray(value) && value.length === 0) return undefined;
@@ -39,6 +41,8 @@ const PodiumAssetJs = class PodiumAssetJs {
         defer = false,
         type = 'default',
         data = [],
+        strategy = undefined,
+        scope = undefined,
     } = {}) {
         if (validate.js(value).error)
             throw new Error(
@@ -57,6 +61,8 @@ const PodiumAssetJs = class PodiumAssetJs {
         this[_defer] = defer;
         this[_type] = type;
         this[_data] = data;
+        this[_strategy] = strategy;
+        this[_scope] = scope;
     }
 
     get referrerpolicy() {
@@ -141,6 +147,22 @@ const PodiumAssetJs = class PodiumAssetJs {
         throw new Error('Cannot set read-only property.');
     }
 
+    get strategy() {
+      return this[_strategy];
+    }
+
+    set strategy(value) {
+        this[_strategy] = value;
+    }
+
+    get scope() {
+      return this[_scope];
+    }
+
+    set scope(value) {
+        this[_scope] = value;
+    }
+
     toJSON() {
         return {
             referrerpolicy: toUndefined(this.referrerpolicy),
@@ -152,6 +174,8 @@ const PodiumAssetJs = class PodiumAssetJs {
             defer: toUndefined(this.defer),
             type: this.type,
             data: toUndefined(this.data),
+            strategy: toUndefined(this.strategy),
+            scope: toUndefined(this.scope),
         };
     }
 

--- a/lib/html-document.js
+++ b/lib/html-document.js
@@ -17,12 +17,14 @@ const document = (incoming = {}, body = '', head = '') => {
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta http-equiv="X-UA-Compatible" content="IE=Edge">
         ${styles.map(utils.buildLinkElement).join('\n        ')}
-        ${scripts.map(utils.buildScriptElement).join('\n        ')}
+        ${scripts.filter((script) => script.strategy === "beforeInteractive").map(utils.buildScriptElement).join('\n        ')}
         <title>${incoming.view.title ? incoming.view.title : ''}</title>
         ${head}
     </head>
     <body>
         ${body}
+        ${scripts.filter((script) => script.strategy === "afterInteractive" || !script.strategy).map(utils.buildScriptElement).join('\n        ')}
+        ${scripts.filter((script) => script.strategy === "lazy").map((script) => `<script type="module">import("${script.value}")</script>`).join('\n        ')}
     </body>
 </html>`;
 };

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
         "semantic-release": "19.0.5"
     },
     "dependencies": {
-        "@podium/schemas": "4.1.34",
+        "@podium/schemas": "4.2.0",
         "camelcase": "6.3.0",
         "original-url": "1.2.3"
     }


### PR DESCRIPTION
This is part of an effort to add strategy and scope fields to Podium JS/CSS assets
See https://github.com/podium-lib/schemas/pull/201

TODO
* Merge https://github.com/podium-lib/schemas/pull/201 and update utils before merging