### PR TITLE
fix: correctly build lazy load script tag html when asset strategy is lazy

### DIFF
--- a/__tests__/asset-js.js
+++ b/__tests__/asset-js.js
@@ -104,7 +104,7 @@ test('Js() - pathname is given - prefix is true - should append pathname to "src
 
 test('Js() - pathname is given - strategy is lazy - should create HTML with dynamic import', () => {
     const obj = new Js({ value: '/foo', strategy: 'lazy' });
-    expect(obj.toHTML()).toEqual('<script type="module">import "/foo";</script>');
+    expect(obj.toHTML()).toEqual('<script type="module">import("/foo");</script>');
 });
 
 test('Js() - value if absoulte - pathname is given - prefix is true - should NOT append pathname to "value"', () => {

--- a/__tests__/asset-js.js
+++ b/__tests__/asset-js.js
@@ -102,6 +102,11 @@ test('Js() - pathname is given - prefix is true - should append pathname to "src
     expect(obj.toHTML()).toEqual('<script src="/bar/foo"></script>');
 });
 
+test('Js() - pathname is given - strategy is lazy - should create HTML with dynamic import', () => {
+    const obj = new Js({ value: '/foo', strategy: 'lazy' });
+    expect(obj.toHTML()).toEqual('<script type="module">import "/foo";</script>');
+});
+
 test('Js() - value if absoulte - pathname is given - prefix is true - should NOT append pathname to "value"', () => {
     const obj = new Js({
         value: 'http://somewhere.else.com/foo',

--- a/__tests__/html-utils.js
+++ b/__tests__/html-utils.js
@@ -385,15 +385,14 @@ test('.buildScriptElement() - crossorigin boolean false', () => {
 test('.buildScriptElement() - strategy lazy - builds HTML with dynamic import', () => {
     const obj = new AssetJs({ value: '/foo', type: 'module', strategy: 'lazy' });
     const result = utils.buildScriptElement(obj);
-    expect(result).toEqual('<script type="module">import "/foo";</script>');
+    expect(result).toEqual('<script type="module">import("/foo");</script>');
 });
 
 test('.buildScriptElement() - strategy lazy - automatically includes type="module" if not provided', () => {
     const obj = new AssetJs({ value: '/foo', strategy: 'lazy' });
     const result = utils.buildScriptElement(obj);
-    expect(result).toEqual('<script type="module">import "/foo";</script>');
+    expect(result).toEqual('<script type="module">import("/foo");</script>');
 });
-
 
 test('.buildScriptAttributes() - basic', () => {
     const obj = new AssetJs({ value: '/bar' });

--- a/__tests__/html-utils.js
+++ b/__tests__/html-utils.js
@@ -382,6 +382,19 @@ test('.buildScriptElement() - crossorigin boolean false', () => {
     expect(result).toEqual(`<script src="/bar"></script>`);
 });
 
+test('.buildScriptElement() - strategy lazy - builds HTML with dynamic import', () => {
+    const obj = new AssetJs({ value: '/foo', type: 'module', strategy: 'lazy' });
+    const result = utils.buildScriptElement(obj);
+    expect(result).toEqual('<script type="module">import "/foo";</script>');
+});
+
+test('.buildScriptElement() - strategy lazy - automatically includes type="module" if not provided', () => {
+    const obj = new AssetJs({ value: '/foo', strategy: 'lazy' });
+    const result = utils.buildScriptElement(obj);
+    expect(result).toEqual('<script type="module">import "/foo";</script>');
+});
+
+
 test('.buildScriptAttributes() - basic', () => {
     const obj = new AssetJs({ value: '/bar' });
     expect(utils.buildScriptAttributes(obj)).toEqual([

--- a/lib/html-utils.js
+++ b/lib/html-utils.js
@@ -12,9 +12,13 @@ const notEmpty = (value) => {
 
 const buildScriptAttributes = (obj) => {
     const args = [];
-    args.push({ key: 'src', value: obj.value });
+    // lazy uses dynamic import in the script body, everything else uses the src attribute
+    if (obj.strategy !== 'lazy') {
+        args.push({ key: 'src', value: obj.value });
+    }
 
-    if (obj.type === 'esm' || obj.type === 'module') {
+    // ESM and module are valid "module" types. Lazy requires type="module" so we set it here.
+    if (obj.type === 'esm' || obj.type === 'module' || obj.strategy === 'lazy') {
         args.push({ key: 'type', value: 'module' });
     }
 
@@ -43,7 +47,7 @@ const buildScriptAttributes = (obj) => {
         args.push({ key: 'defer' });
     }
 
-    if (Array.isArray(obj.data) && (obj.data.length !== 0)) {
+    if (Array.isArray(obj.data) && obj.data.length !== 0) {
         obj.data.forEach((item) => {
             args.push({ key: `data-${item.key}`, value: item.value });
         });
@@ -69,7 +73,7 @@ const buildScriptElement = (obj) => {
         if (!value && value !== '') return key;
         return `${key}="${value}"`;
     })
-    return `<script ${attrs.join(' ')}></script>`;
+    return `<script ${attrs.join(' ')}>${obj.strategy === 'lazy' ? `import "${obj.value}";` : ''}</script>`;
 };
 
 const buildLinkAttributes = (obj) => {

--- a/lib/html-utils.js
+++ b/lib/html-utils.js
@@ -73,7 +73,7 @@ const buildScriptElement = (obj) => {
         if (!value && value !== '') return key;
         return `${key}="${value}"`;
     })
-    return `<script ${attrs.join(' ')}>${obj.strategy === 'lazy' ? `import "${obj.value}";` : ''}</script>`;
+    return `<script ${attrs.join(' ')}>${obj.strategy === 'lazy' ? `import("${obj.value}");` : ''}</script>`;
 };
 
 const buildLinkAttributes = (obj) => {


### PR DESCRIPTION
Uses dynamic imports to inside script tags for script assets that have the lazy load strategy.

Auto detects the strategy property on the asset when calling toHTML

```js
script.toHTML()
```

Which produces a script tag that looks like:

```html
<script type="module">import("/path/to/file.js");</script>
```

