### PR TITLE
fix: disallow replacing #css and #js internal array

### DIFF
--- a/lib/http-incoming.js
+++ b/lib/http-incoming.js
@@ -2,7 +2,7 @@ import { URL } from 'node:url';
 
 const inspect = Symbol.for('nodejs.util.inspect.custom');
 
-const urlFromRequest = request => {
+const urlFromRequest = (request) => {
     const protocol = request?.protocol || 'http';
     const host = request?.headers?.host || 'localhost';
     const url = request?.url || '';
@@ -33,7 +33,6 @@ export default class HttpIncoming {
         this.#url = undefined;
         this.#css = [];
         this.#js = [];
-
     }
 
     set development(value) {
@@ -71,15 +70,15 @@ export default class HttpIncoming {
     set podlets(value) {
         const podlets = Array.isArray(value) ? value : [value];
 
-        podlets.forEach(podlet => {
+        podlets.forEach((podlet) => {
             if (podlet.css) {
-                podlet.css.forEach(item => {
+                podlet.css.forEach((item) => {
                     this.#css.push(item);
                 });
             }
 
             if (podlet.js) {
-                podlet.js.forEach(item => {
+                podlet.js.forEach((item) => {
                     this.#js.push(item);
                 });
             }
@@ -130,12 +129,17 @@ export default class HttpIncoming {
 
     get url() {
         if (this.#url) return this.#url;
-        return urlFromRequest(this.#request);;
+        return urlFromRequest(this.#request);
     }
 
     set css(value) {
-        if (!Array.isArray(value))
+        if (!Array.isArray(value)) {
             throw new Error(`Value for property ".css" must be an Array`);
+        }
+        if (this.#css) {
+            this.#css = this.#css.concat(value);
+            return;
+        }
         this.#css = value;
     }
 
@@ -144,8 +148,13 @@ export default class HttpIncoming {
     }
 
     set js(value) {
-        if (!Array.isArray(value))
+        if (!Array.isArray(value)) {
             throw new Error(`Value for property ".js" must be an Array`);
+        }
+        if (this.#js) {
+            this.#js = this.#js.concat(value);
+            return;
+        }
         this.#js = value;
     }
 
@@ -182,8 +191,8 @@ export default class HttpIncoming {
             js: this.js,
         };
     }
-    
+
     get [Symbol.toStringTag]() {
         return 'PodiumHttpIncoming';
     }
-};
+}


### PR DESCRIPTION
If users try to use both `layout.js()` and set `incoming.js = []` the scripts set by `layout.js()` disappear with no clear indication why.