### PR TITLE
fix: ensure html-template lang attribute works in both layout and podlet

### DIFF
--- a/lib/html-document.js
+++ b/lib/html-document.js
@@ -3,13 +3,14 @@ import * as utils from './html-utils.js';
 export const document = (incoming = {}, body = '', head = '') => {
     let scripts = incoming.js;
     let styles = incoming.css;
+    const lang = incoming.view.locale || incoming.context['podium-locale'] || incoming.context.locale || incoming.params.locale || 'en-US';
 
     // backwards compatibility for scripts and styles
     if (typeof incoming.js === 'string') scripts = [{ type: 'default', value: incoming.js }];
     if (typeof incoming.css === 'string') styles = [{ type: 'text/css', value: incoming.css, rel: 'stylesheet' }];
 
     return `<!doctype html>
-<html lang="${incoming.context.locale ? incoming.context.locale : 'en-US'}">
+<html lang="${lang}">
     <head>
         <meta charset="${incoming.view.encoding ? incoming.view.encoding : 'utf-8'}">
         <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/tests/html-document.js
+++ b/tests/html-document.js
@@ -87,3 +87,27 @@ tap.test('.document() - "type" is "module", "strategy" is set - should place ass
     t.matchSnapshot(result);
     t.end();
 });
+
+tap.test('.document() - lang tag priority - params has priority', (t) => {
+    const incoming = new HttpIncoming(SIMPLE_REQ, SIMPLE_RES, { locale: 'sv' });
+    const result = document(incoming, '');
+    t.match(result, 'lang="sv"', 'should render lang tag sv');
+    t.end();
+});
+
+tap.test('.document() - lang tag priority - context has priority', (t) => {
+    const incoming = new HttpIncoming(SIMPLE_REQ, SIMPLE_RES, { locale: 'sv' });
+    incoming.context = { locale: 'en-NZ' };
+    const result = document(incoming, '');
+    t.match(result, 'lang="en-NZ"', 'should render lang tag en-NZ');
+    t.end();
+});
+
+tap.test('.document() - lang tag priority - view has priority', (t) => {
+    const incoming = new HttpIncoming(SIMPLE_REQ, SIMPLE_RES, { locale: 'sv' });
+    incoming.context = { locale: 'en-NZ' };
+    incoming.view = { locale: 'nb' }
+    const result = document(incoming, '');
+    t.match(result, 'lang="nb"', 'should render lang tag nb');
+    t.end();
+});


### PR DESCRIPTION
This template is probably not often used, certainly not in NMP which is why we've probably never noticed that the lang 
attribute wasn't actually working in podlets.

This PR also introduces a priority order for determining lang from locale:
* incoming.view is at the app level and takes highest priority, if an app sets this directly, thats the value.
* incoming.context is used for values synced between the layout and the podlet. Due to differences between layouts and podlets, we have to check both incoming.context['podium-locale'] for layouts and incoming.context.locale for podlets.
* fallback to incoming.params which is set in Podium layout and podlet middleware/plugins. I see this as a value that can be used by other middleware or abstractions to set values that the html-template can make use of. In the case of locale/lang, I believe it should be lower priority than the context but correct me if that seems wrong.
* finally, a default of en-US is set.