### PR TITLE
fix: include the types folder in the distributed package

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "LICENSE",
     "dist",
     "lib",
-    "types.d.ts"
+    "types"
   ],
   "main": "./lib/main.js",
   "types": "./types/main.d.ts",


### PR DESCRIPTION
It's not being included even with `"types"` set to what it is on L31