### PR TITLE
feat: add toHeader methods to Asset classes

### DIFF
--- a/lib/asset-css.js
+++ b/lib/asset-css.js
@@ -224,6 +224,13 @@ export default class PodiumAssetCss {
         return buildLinkElement(this);
     }
 
+    toEarlyHint() {
+        const attrs = Object.entries(this.toJSON())
+            .filter(([key, value]) => value && key !== 'value')
+            .map(([key, value]) => `${key}="${value}";`);
+        return `<${this.#value}>; ${attrs.join(' ')}`;
+    }
+
     [inspect]() {
         return {
             crossorigin: this.crossorigin,

--- a/lib/asset-css.js
+++ b/lib/asset-css.js
@@ -224,7 +224,7 @@ export default class PodiumAssetCss {
         return buildLinkElement(this);
     }
 
-    toEarlyHint() {
+    toHeader() {
         const attrs = Object.entries(this.toJSON())
             .filter(([key, value]) => value && key !== 'value')
             .map(([key, value]) => `${key}=${value}`);

--- a/lib/asset-css.js
+++ b/lib/asset-css.js
@@ -227,8 +227,8 @@ export default class PodiumAssetCss {
     toEarlyHint() {
         const attrs = Object.entries(this.toJSON())
             .filter(([key, value]) => value && key !== 'value')
-            .map(([key, value]) => `${key}="${value}";`);
-        return `<${this.#value}>; ${attrs.join(' ')}`;
+            .map(([key, value]) => `${key}=${value}`);
+        return `<${this.#value}>; ${attrs.join('; ')}`;
     }
 
     [inspect]() {

--- a/lib/asset-js.js
+++ b/lib/asset-js.js
@@ -234,6 +234,21 @@ export default class PodiumAssetJs {
         return buildScriptElement(this);
     }
 
+    toEarlyHint() {
+        const attrs = Object.entries(this.toJSON())
+            .filter(([key, value]) => value && key !== 'value')
+            .flatMap(([key, value]) => {
+                if (key === 'data') {
+                    // @ts-ignore
+                    return value.map(
+                        ({ key, value }) => `data-${key}="${value}";`,
+                    );
+                }
+                return [`${key}="${value}";`];
+            });
+        return `<${this.#value}>; ${attrs.join(' ')}`;
+    }
+
     [inspect]() {
         return {
             referrerpolicy: this.referrerpolicy,

--- a/lib/asset-js.js
+++ b/lib/asset-js.js
@@ -234,7 +234,7 @@ export default class PodiumAssetJs {
         return buildScriptElement(this);
     }
 
-    toEarlyHint() {
+    toHeader() {
         const attrs = Object.entries(this.toJSON())
             .filter(([key, value]) => value && key !== 'value')
             .flatMap(([key, value]) => {

--- a/lib/asset-js.js
+++ b/lib/asset-js.js
@@ -244,7 +244,7 @@ export default class PodiumAssetJs {
                         ({ key, value }) => `data-${key}="${value}";`,
                     );
                 }
-                return [`${key}="${value}";`];
+                return [`${key}=${value};`];
             });
         return `<${this.#value}>; ${attrs.join(' ')}`;
     }

--- a/lib/asset-js.js
+++ b/lib/asset-js.js
@@ -241,12 +241,12 @@ export default class PodiumAssetJs {
                 if (key === 'data') {
                     // @ts-ignore
                     return value.map(
-                        ({ key, value }) => `data-${key}="${value}";`,
+                        ({ key, value }) => `data-${key}=${value}`,
                     );
                 }
-                return [`${key}=${value};`];
+                return [`${key}=${value}`];
             });
-        return `<${this.#value}>; ${attrs.join(' ')}`;
+        return `<${this.#value}>; ${attrs.join('; ')}`;
     }
 
     [inspect]() {

--- a/tests/asset-css.test.js
+++ b/tests/asset-css.test.js
@@ -235,7 +235,7 @@ tap.test(
         });
 
         t.equal(
-            obj.toEarlyHint(),
+            obj.toHeader(),
             '</foo>; crossorigin=bar; type=text/css; rel=stylesheet',
         );
 
@@ -269,7 +269,7 @@ tap.test(
         });
 
         t.equal(
-            obj.toEarlyHint(),
+            obj.toHeader(),
             '</foo>; disabled=true; type=text/css; rel=stylesheet',
         );
 
@@ -303,7 +303,7 @@ tap.test(
         });
 
         t.equal(
-            obj.toEarlyHint(),
+            obj.toHeader(),
             '</foo>; hreflang=bar; type=text/css; rel=stylesheet',
         );
 
@@ -334,10 +334,7 @@ tap.test('Css() - set "title" - should construct object as expected', (t) => {
         rel: 'stylesheet',
     });
 
-    t.equal(
-        obj.toEarlyHint(),
-        '</foo>; title=bar; type=text/css; rel=stylesheet',
-    );
+    t.equal(obj.toHeader(), '</foo>; title=bar; type=text/css; rel=stylesheet');
 
     const repl = new AssetCss(json);
     t.equal(repl.title, 'bar');
@@ -365,10 +362,7 @@ tap.test('Css() - set "media" - should construct object as expected', (t) => {
         rel: 'stylesheet',
     });
 
-    t.equal(
-        obj.toEarlyHint(),
-        '</foo>; media=bar; type=text/css; rel=stylesheet',
-    );
+    t.equal(obj.toHeader(), '</foo>; media=bar; type=text/css; rel=stylesheet');
 
     const repl = new AssetCss(json);
     t.equal(repl.media, 'bar');
@@ -392,7 +386,7 @@ tap.test('Css() - set "type" - should construct object as expected', (t) => {
         rel: 'stylesheet',
     });
 
-    t.equal(obj.toEarlyHint(), '</foo>; type=bar; rel=stylesheet');
+    t.equal(obj.toHeader(), '</foo>; type=bar; rel=stylesheet');
 
     const repl = new AssetCss(json);
     t.equal(repl.type, 'bar');
@@ -416,7 +410,7 @@ tap.test('Css() - set "rel" - should construct object as expected', (t) => {
         rel: 'bar',
     });
 
-    t.equal(obj.toEarlyHint(), '</foo>; type=text/css; rel=bar');
+    t.equal(obj.toHeader(), '</foo>; type=text/css; rel=bar');
 
     const repl = new AssetCss(json);
     t.equal(repl.rel, 'bar');
@@ -444,7 +438,7 @@ tap.test('Css() - set "as" - should construct object as expected', (t) => {
         rel: 'stylesheet',
     });
 
-    t.equal(obj.toEarlyHint(), '</foo>; type=text/css; rel=stylesheet; as=bar');
+    t.equal(obj.toHeader(), '</foo>; type=text/css; rel=stylesheet; as=bar');
 
     const repl = new AssetCss(json);
     t.equal(repl.as, 'bar');

--- a/tests/asset-css.test.js
+++ b/tests/asset-css.test.js
@@ -234,6 +234,11 @@ tap.test(
             rel: 'stylesheet',
         });
 
+        t.equal(
+            obj.toEarlyHint(),
+            '</foo>; crossorigin="bar"; type="text/css"; rel="stylesheet";',
+        );
+
         const repl = new AssetCss(json);
         t.equal(repl.crossorigin, 'bar');
         t.end();
@@ -262,6 +267,11 @@ tap.test(
             type: 'text/css',
             rel: 'stylesheet',
         });
+
+        t.equal(
+            obj.toEarlyHint(),
+            '</foo>; disabled="true"; type="text/css"; rel="stylesheet";',
+        );
 
         const repl = new AssetCss(json);
         t.ok(repl.disabled);
@@ -292,6 +302,11 @@ tap.test(
             rel: 'stylesheet',
         });
 
+        t.equal(
+            obj.toEarlyHint(),
+            '</foo>; hreflang="bar"; type="text/css"; rel="stylesheet";',
+        );
+
         const repl = new AssetCss(json);
         t.equal(repl.hreflang, 'bar');
         t.end();
@@ -319,6 +334,11 @@ tap.test('Css() - set "title" - should construct object as expected', (t) => {
         rel: 'stylesheet',
     });
 
+    t.equal(
+        obj.toEarlyHint(),
+        '</foo>; title="bar"; type="text/css"; rel="stylesheet";',
+    );
+
     const repl = new AssetCss(json);
     t.equal(repl.title, 'bar');
     t.end();
@@ -345,6 +365,11 @@ tap.test('Css() - set "media" - should construct object as expected', (t) => {
         rel: 'stylesheet',
     });
 
+    t.equal(
+        obj.toEarlyHint(),
+        '</foo>; media="bar"; type="text/css"; rel="stylesheet";',
+    );
+
     const repl = new AssetCss(json);
     t.equal(repl.media, 'bar');
     t.end();
@@ -367,6 +392,8 @@ tap.test('Css() - set "type" - should construct object as expected', (t) => {
         rel: 'stylesheet',
     });
 
+    t.equal(obj.toEarlyHint(), '</foo>; type="bar"; rel="stylesheet";');
+
     const repl = new AssetCss(json);
     t.equal(repl.type, 'bar');
     t.end();
@@ -388,6 +415,8 @@ tap.test('Css() - set "rel" - should construct object as expected', (t) => {
         type: 'text/css',
         rel: 'bar',
     });
+
+    t.equal(obj.toEarlyHint(), '</foo>; type="text/css"; rel="bar";');
 
     const repl = new AssetCss(json);
     t.equal(repl.rel, 'bar');
@@ -414,6 +443,11 @@ tap.test('Css() - set "as" - should construct object as expected', (t) => {
         type: 'text/css',
         rel: 'stylesheet',
     });
+
+    t.equal(
+        obj.toEarlyHint(),
+        '</foo>; type="text/css"; rel="stylesheet"; as="bar";',
+    );
 
     const repl = new AssetCss(json);
     t.equal(repl.as, 'bar');

--- a/tests/asset-css.test.js
+++ b/tests/asset-css.test.js
@@ -236,7 +236,7 @@ tap.test(
 
         t.equal(
             obj.toEarlyHint(),
-            '</foo>; crossorigin="bar"; type="text/css"; rel="stylesheet";',
+            '</foo>; crossorigin=bar; type=text/css; rel=stylesheet',
         );
 
         const repl = new AssetCss(json);
@@ -270,7 +270,7 @@ tap.test(
 
         t.equal(
             obj.toEarlyHint(),
-            '</foo>; disabled="true"; type="text/css"; rel="stylesheet";',
+            '</foo>; disabled=true; type=text/css; rel=stylesheet',
         );
 
         const repl = new AssetCss(json);
@@ -304,7 +304,7 @@ tap.test(
 
         t.equal(
             obj.toEarlyHint(),
-            '</foo>; hreflang="bar"; type="text/css"; rel="stylesheet";',
+            '</foo>; hreflang=bar; type=text/css; rel=stylesheet',
         );
 
         const repl = new AssetCss(json);
@@ -336,7 +336,7 @@ tap.test('Css() - set "title" - should construct object as expected', (t) => {
 
     t.equal(
         obj.toEarlyHint(),
-        '</foo>; title="bar"; type="text/css"; rel="stylesheet";',
+        '</foo>; title=bar; type=text/css; rel=stylesheet',
     );
 
     const repl = new AssetCss(json);
@@ -367,7 +367,7 @@ tap.test('Css() - set "media" - should construct object as expected', (t) => {
 
     t.equal(
         obj.toEarlyHint(),
-        '</foo>; media="bar"; type="text/css"; rel="stylesheet";',
+        '</foo>; media=bar; type=text/css; rel=stylesheet',
     );
 
     const repl = new AssetCss(json);
@@ -392,7 +392,7 @@ tap.test('Css() - set "type" - should construct object as expected', (t) => {
         rel: 'stylesheet',
     });
 
-    t.equal(obj.toEarlyHint(), '</foo>; type="bar"; rel="stylesheet";');
+    t.equal(obj.toEarlyHint(), '</foo>; type=bar; rel=stylesheet');
 
     const repl = new AssetCss(json);
     t.equal(repl.type, 'bar');
@@ -416,7 +416,7 @@ tap.test('Css() - set "rel" - should construct object as expected', (t) => {
         rel: 'bar',
     });
 
-    t.equal(obj.toEarlyHint(), '</foo>; type="text/css"; rel="bar";');
+    t.equal(obj.toEarlyHint(), '</foo>; type=text/css; rel=bar');
 
     const repl = new AssetCss(json);
     t.equal(repl.rel, 'bar');
@@ -444,10 +444,7 @@ tap.test('Css() - set "as" - should construct object as expected', (t) => {
         rel: 'stylesheet',
     });
 
-    t.equal(
-        obj.toEarlyHint(),
-        '</foo>; type="text/css"; rel="stylesheet"; as="bar";',
-    );
+    t.equal(obj.toEarlyHint(), '</foo>; type=text/css; rel=stylesheet; as=bar');
 
     const repl = new AssetCss(json);
     t.equal(repl.as, 'bar');

--- a/tests/asset-js.test.js
+++ b/tests/asset-js.test.js
@@ -219,10 +219,7 @@ tap.test(
             type: 'default',
         });
 
-        t.equal(
-            obj.toEarlyHint(),
-            '</foo>; referrerpolicy="bar"; type="default";',
-        );
+        t.equal(obj.toEarlyHint(), '</foo>; referrerpolicy=bar; type=default');
 
         const repl = new AssetJs(json);
         t.equal(repl.referrerpolicy, 'bar');
@@ -249,10 +246,7 @@ tap.test(
             type: 'default',
         });
 
-        t.equal(
-            obj.toEarlyHint(),
-            '</foo>; crossorigin="bar"; type="default";',
-        );
+        t.equal(obj.toEarlyHint(), '</foo>; crossorigin=bar; type=default');
 
         const repl = new AssetJs(json);
         t.equal(repl.crossorigin, 'bar');
@@ -279,7 +273,7 @@ tap.test(
             type: 'default',
         });
 
-        t.equal(obj.toEarlyHint(), '</foo>; integrity="bar"; type="default";');
+        t.equal(obj.toEarlyHint(), '</foo>; integrity=bar; type=default');
 
         const repl = new AssetJs(json);
         t.equal(repl.integrity, 'bar');
@@ -306,7 +300,7 @@ tap.test(
             type: 'default',
         });
 
-        t.equal(obj.toEarlyHint(), '</foo>; nomodule="true"; type="default";');
+        t.equal(obj.toEarlyHint(), '</foo>; nomodule=true; type=default');
 
         const repl = new AssetJs(json);
         t.ok(repl.nomodule);
@@ -331,7 +325,7 @@ tap.test('Js() - set "async" - should construct object as t.equaled', (t) => {
         type: 'default',
     });
 
-    t.equal(obj.toEarlyHint(), '</foo>; async="true"; type="default";');
+    t.equal(obj.toEarlyHint(), '</foo>; async=true; type=default');
 
     const repl = new AssetJs(json);
     t.ok(repl.async);
@@ -355,7 +349,7 @@ tap.test('Js() - set "defer" - should construct object as t.equaled', (t) => {
         type: 'default',
     });
 
-    t.equal(obj.toEarlyHint(), '</foo>; defer="true"; type="default";');
+    t.equal(obj.toEarlyHint(), '</foo>; defer=true; type=default');
 
     const repl = new AssetJs(json);
     t.ok(repl.defer);
@@ -378,7 +372,7 @@ tap.test('Js() - set "type" - should construct object as t.equaled', (t) => {
         type: 'esm',
     });
 
-    t.equal(obj.toEarlyHint(), '</foo>; type="esm";');
+    t.equal(obj.toEarlyHint(), '</foo>; type=esm');
 
     const repl = new AssetJs(json);
     t.equal(repl.type, 'esm');
@@ -417,7 +411,7 @@ tap.test('Js() - set "data" - should construct object as t.equaled', (t) => {
         type: 'default',
     });
 
-    t.equal(obj.toEarlyHint(), '</foo>; type="default"; data-foo="bar";');
+    t.equal(obj.toEarlyHint(), '</foo>; type=default; data-foo=bar');
 
     const repl = new AssetJs(json);
     t.same(repl.data, [

--- a/tests/asset-js.test.js
+++ b/tests/asset-js.test.js
@@ -219,7 +219,7 @@ tap.test(
             type: 'default',
         });
 
-        t.equal(obj.toEarlyHint(), '</foo>; referrerpolicy=bar; type=default');
+        t.equal(obj.toHeader(), '</foo>; referrerpolicy=bar; type=default');
 
         const repl = new AssetJs(json);
         t.equal(repl.referrerpolicy, 'bar');
@@ -246,7 +246,7 @@ tap.test(
             type: 'default',
         });
 
-        t.equal(obj.toEarlyHint(), '</foo>; crossorigin=bar; type=default');
+        t.equal(obj.toHeader(), '</foo>; crossorigin=bar; type=default');
 
         const repl = new AssetJs(json);
         t.equal(repl.crossorigin, 'bar');
@@ -273,7 +273,7 @@ tap.test(
             type: 'default',
         });
 
-        t.equal(obj.toEarlyHint(), '</foo>; integrity=bar; type=default');
+        t.equal(obj.toHeader(), '</foo>; integrity=bar; type=default');
 
         const repl = new AssetJs(json);
         t.equal(repl.integrity, 'bar');
@@ -300,7 +300,7 @@ tap.test(
             type: 'default',
         });
 
-        t.equal(obj.toEarlyHint(), '</foo>; nomodule=true; type=default');
+        t.equal(obj.toHeader(), '</foo>; nomodule=true; type=default');
 
         const repl = new AssetJs(json);
         t.ok(repl.nomodule);
@@ -325,7 +325,7 @@ tap.test('Js() - set "async" - should construct object as t.equaled', (t) => {
         type: 'default',
     });
 
-    t.equal(obj.toEarlyHint(), '</foo>; async=true; type=default');
+    t.equal(obj.toHeader(), '</foo>; async=true; type=default');
 
     const repl = new AssetJs(json);
     t.ok(repl.async);
@@ -349,7 +349,7 @@ tap.test('Js() - set "defer" - should construct object as t.equaled', (t) => {
         type: 'default',
     });
 
-    t.equal(obj.toEarlyHint(), '</foo>; defer=true; type=default');
+    t.equal(obj.toHeader(), '</foo>; defer=true; type=default');
 
     const repl = new AssetJs(json);
     t.ok(repl.defer);
@@ -372,7 +372,7 @@ tap.test('Js() - set "type" - should construct object as t.equaled', (t) => {
         type: 'esm',
     });
 
-    t.equal(obj.toEarlyHint(), '</foo>; type=esm');
+    t.equal(obj.toHeader(), '</foo>; type=esm');
 
     const repl = new AssetJs(json);
     t.equal(repl.type, 'esm');
@@ -411,7 +411,7 @@ tap.test('Js() - set "data" - should construct object as t.equaled', (t) => {
         type: 'default',
     });
 
-    t.equal(obj.toEarlyHint(), '</foo>; type=default; data-foo=bar');
+    t.equal(obj.toHeader(), '</foo>; type=default; data-foo=bar');
 
     const repl = new AssetJs(json);
     t.same(repl.data, [

--- a/tests/asset-js.test.js
+++ b/tests/asset-js.test.js
@@ -219,6 +219,11 @@ tap.test(
             type: 'default',
         });
 
+        t.equal(
+            obj.toEarlyHint(),
+            '</foo>; referrerpolicy="bar"; type="default";',
+        );
+
         const repl = new AssetJs(json);
         t.equal(repl.referrerpolicy, 'bar');
         t.end();
@@ -243,6 +248,11 @@ tap.test(
             value: '/foo',
             type: 'default',
         });
+
+        t.equal(
+            obj.toEarlyHint(),
+            '</foo>; crossorigin="bar"; type="default";',
+        );
 
         const repl = new AssetJs(json);
         t.equal(repl.crossorigin, 'bar');
@@ -269,6 +279,8 @@ tap.test(
             type: 'default',
         });
 
+        t.equal(obj.toEarlyHint(), '</foo>; integrity="bar"; type="default";');
+
         const repl = new AssetJs(json);
         t.equal(repl.integrity, 'bar');
         t.end();
@@ -294,6 +306,8 @@ tap.test(
             type: 'default',
         });
 
+        t.equal(obj.toEarlyHint(), '</foo>; nomodule="true"; type="default";');
+
         const repl = new AssetJs(json);
         t.ok(repl.nomodule);
         t.end();
@@ -317,6 +331,8 @@ tap.test('Js() - set "async" - should construct object as t.equaled', (t) => {
         type: 'default',
     });
 
+    t.equal(obj.toEarlyHint(), '</foo>; async="true"; type="default";');
+
     const repl = new AssetJs(json);
     t.ok(repl.async);
     t.end();
@@ -339,6 +355,8 @@ tap.test('Js() - set "defer" - should construct object as t.equaled', (t) => {
         type: 'default',
     });
 
+    t.equal(obj.toEarlyHint(), '</foo>; defer="true"; type="default";');
+
     const repl = new AssetJs(json);
     t.ok(repl.defer);
     t.end();
@@ -359,6 +377,8 @@ tap.test('Js() - set "type" - should construct object as t.equaled', (t) => {
         value: '/foo',
         type: 'esm',
     });
+
+    t.equal(obj.toEarlyHint(), '</foo>; type="esm";');
 
     const repl = new AssetJs(json);
     t.equal(repl.type, 'esm');
@@ -396,6 +416,8 @@ tap.test('Js() - set "data" - should construct object as t.equaled', (t) => {
         ],
         type: 'default',
     });
+
+    t.equal(obj.toEarlyHint(), '</foo>; type="default"; data-foo="bar";');
 
     const repl = new AssetJs(json);
     t.same(repl.data, [


### PR DESCRIPTION
Adds toHeader methods to both AssetCss and AssetJs.

Couple thoughts.

1. Early hints are typically used to produce preload Link headers so perhaps .toHeader would actually be a better name since thats what's happening here. (done, renamed to toHeader)
2. While the strings being produced are (I believe) strictly valid for sending as Link headers, they are highly non standard since we send all kinds of properties that the browser isn't going to do anything with. I think this is necessary since we want to basically use the Link header string as a full serialisation of the AssetJs or AssetCss object so it can be sent to the layout. Anything less would make many of the asset properties useless as they would never make it to the layout. See diagram below for how I think this all fits together.
3. We might want to add .fromHeader(string) methods as well so that the layout can have an easy time of parsing the Link strings back into AssetCss and AssetJs objects. Or a separate utility that returns an array of AssetJs and/or AssetCss objects might be better

```mermaid
graph TD;
    A[podlet] -- Early hint with custom Link header properties  --> B[layout];
    B -- Early hint with standard Link header properties --> C[browser];
    B -- Body with regular asset links/scripts --> C;
```

1. **Early hint with custom Link header syntax**: The podlet sends the fully serialised AssetJs and AssetCss objects to the layout client in the form of a Link header
2. **Early hint with standard Link header syntax**: The layout deserialises the Link header from the podlet back into AssetJs and AssetCss objects where it then creates preload Link headers and sends them to the browser as early hints before including the assets in the document template with the rest of the payload sent via podiumSend.