### PR TITLE
feat: add asset-type link header attribute and set to either style or script

### DIFF
--- a/lib/asset-css.js
+++ b/lib/asset-css.js
@@ -228,7 +228,7 @@ export default class PodiumAssetCss {
         const attrs = Object.entries(this.toJSON())
             .filter(([key, value]) => value && key !== 'value')
             .map(([key, value]) => `${key}=${value}`);
-        return `<${this.#value}>; ${attrs.join('; ')}`;
+        return `<${this.#value}>; ${attrs.join('; ')}; asset-type=style`;
     }
 
     [inspect]() {

--- a/lib/asset-js.js
+++ b/lib/asset-js.js
@@ -246,7 +246,7 @@ export default class PodiumAssetJs {
                 }
                 return [`${key}=${value}`];
             });
-        return `<${this.#value}>; ${attrs.join('; ')}`;
+        return `<${this.#value}>; ${attrs.join('; ')}; asset-type=script`;
     }
 
     [inspect]() {

--- a/tests/asset-css.test.js
+++ b/tests/asset-css.test.js
@@ -236,7 +236,7 @@ tap.test(
 
         t.equal(
             obj.toHeader(),
-            '</foo>; crossorigin=bar; type=text/css; rel=stylesheet',
+            '</foo>; crossorigin=bar; type=text/css; rel=stylesheet; asset-type=style',
         );
 
         const repl = new AssetCss(json);
@@ -270,7 +270,7 @@ tap.test(
 
         t.equal(
             obj.toHeader(),
-            '</foo>; disabled=true; type=text/css; rel=stylesheet',
+            '</foo>; disabled=true; type=text/css; rel=stylesheet; asset-type=style',
         );
 
         const repl = new AssetCss(json);
@@ -304,7 +304,7 @@ tap.test(
 
         t.equal(
             obj.toHeader(),
-            '</foo>; hreflang=bar; type=text/css; rel=stylesheet',
+            '</foo>; hreflang=bar; type=text/css; rel=stylesheet; asset-type=style',
         );
 
         const repl = new AssetCss(json);
@@ -334,7 +334,7 @@ tap.test('Css() - set "title" - should construct object as expected', (t) => {
         rel: 'stylesheet',
     });
 
-    t.equal(obj.toHeader(), '</foo>; title=bar; type=text/css; rel=stylesheet');
+    t.equal(obj.toHeader(), '</foo>; title=bar; type=text/css; rel=stylesheet; asset-type=style');
 
     const repl = new AssetCss(json);
     t.equal(repl.title, 'bar');
@@ -362,7 +362,7 @@ tap.test('Css() - set "media" - should construct object as expected', (t) => {
         rel: 'stylesheet',
     });
 
-    t.equal(obj.toHeader(), '</foo>; media=bar; type=text/css; rel=stylesheet');
+    t.equal(obj.toHeader(), '</foo>; media=bar; type=text/css; rel=stylesheet; asset-type=style');
 
     const repl = new AssetCss(json);
     t.equal(repl.media, 'bar');
@@ -386,7 +386,7 @@ tap.test('Css() - set "type" - should construct object as expected', (t) => {
         rel: 'stylesheet',
     });
 
-    t.equal(obj.toHeader(), '</foo>; type=bar; rel=stylesheet');
+    t.equal(obj.toHeader(), '</foo>; type=bar; rel=stylesheet; asset-type=style');
 
     const repl = new AssetCss(json);
     t.equal(repl.type, 'bar');
@@ -410,7 +410,7 @@ tap.test('Css() - set "rel" - should construct object as expected', (t) => {
         rel: 'bar',
     });
 
-    t.equal(obj.toHeader(), '</foo>; type=text/css; rel=bar');
+    t.equal(obj.toHeader(), '</foo>; type=text/css; rel=bar; asset-type=style');
 
     const repl = new AssetCss(json);
     t.equal(repl.rel, 'bar');
@@ -438,7 +438,7 @@ tap.test('Css() - set "as" - should construct object as expected', (t) => {
         rel: 'stylesheet',
     });
 
-    t.equal(obj.toHeader(), '</foo>; type=text/css; rel=stylesheet; as=bar');
+    t.equal(obj.toHeader(), '</foo>; type=text/css; rel=stylesheet; as=bar; asset-type=style');
 
     const repl = new AssetCss(json);
     t.equal(repl.as, 'bar');

--- a/tests/asset-css.test.js
+++ b/tests/asset-css.test.js
@@ -334,7 +334,10 @@ tap.test('Css() - set "title" - should construct object as expected', (t) => {
         rel: 'stylesheet',
     });
 
-    t.equal(obj.toHeader(), '</foo>; title=bar; type=text/css; rel=stylesheet; asset-type=style');
+    t.equal(
+        obj.toHeader(),
+        '</foo>; title=bar; type=text/css; rel=stylesheet; asset-type=style',
+    );
 
     const repl = new AssetCss(json);
     t.equal(repl.title, 'bar');
@@ -362,7 +365,10 @@ tap.test('Css() - set "media" - should construct object as expected', (t) => {
         rel: 'stylesheet',
     });
 
-    t.equal(obj.toHeader(), '</foo>; media=bar; type=text/css; rel=stylesheet; asset-type=style');
+    t.equal(
+        obj.toHeader(),
+        '</foo>; media=bar; type=text/css; rel=stylesheet; asset-type=style',
+    );
 
     const repl = new AssetCss(json);
     t.equal(repl.media, 'bar');
@@ -386,7 +392,10 @@ tap.test('Css() - set "type" - should construct object as expected', (t) => {
         rel: 'stylesheet',
     });
 
-    t.equal(obj.toHeader(), '</foo>; type=bar; rel=stylesheet; asset-type=style');
+    t.equal(
+        obj.toHeader(),
+        '</foo>; type=bar; rel=stylesheet; asset-type=style',
+    );
 
     const repl = new AssetCss(json);
     t.equal(repl.type, 'bar');
@@ -438,7 +447,10 @@ tap.test('Css() - set "as" - should construct object as expected', (t) => {
         rel: 'stylesheet',
     });
 
-    t.equal(obj.toHeader(), '</foo>; type=text/css; rel=stylesheet; as=bar; asset-type=style');
+    t.equal(
+        obj.toHeader(),
+        '</foo>; type=text/css; rel=stylesheet; as=bar; asset-type=style',
+    );
 
     const repl = new AssetCss(json);
     t.equal(repl.as, 'bar');

--- a/tests/asset-js.test.js
+++ b/tests/asset-js.test.js
@@ -219,7 +219,10 @@ tap.test(
             type: 'default',
         });
 
-        t.equal(obj.toHeader(), '</foo>; referrerpolicy=bar; type=default');
+        t.equal(
+            obj.toHeader(),
+            '</foo>; referrerpolicy=bar; type=default; asset-type=script',
+        );
 
         const repl = new AssetJs(json);
         t.equal(repl.referrerpolicy, 'bar');
@@ -246,7 +249,10 @@ tap.test(
             type: 'default',
         });
 
-        t.equal(obj.toHeader(), '</foo>; crossorigin=bar; type=default');
+        t.equal(
+            obj.toHeader(),
+            '</foo>; crossorigin=bar; type=default; asset-type=script',
+        );
 
         const repl = new AssetJs(json);
         t.equal(repl.crossorigin, 'bar');
@@ -273,7 +279,10 @@ tap.test(
             type: 'default',
         });
 
-        t.equal(obj.toHeader(), '</foo>; integrity=bar; type=default');
+        t.equal(
+            obj.toHeader(),
+            '</foo>; integrity=bar; type=default; asset-type=script',
+        );
 
         const repl = new AssetJs(json);
         t.equal(repl.integrity, 'bar');
@@ -300,7 +309,10 @@ tap.test(
             type: 'default',
         });
 
-        t.equal(obj.toHeader(), '</foo>; nomodule=true; type=default');
+        t.equal(
+            obj.toHeader(),
+            '</foo>; nomodule=true; type=default; asset-type=script',
+        );
 
         const repl = new AssetJs(json);
         t.ok(repl.nomodule);
@@ -325,7 +337,10 @@ tap.test('Js() - set "async" - should construct object as t.equaled', (t) => {
         type: 'default',
     });
 
-    t.equal(obj.toHeader(), '</foo>; async=true; type=default');
+    t.equal(
+        obj.toHeader(),
+        '</foo>; async=true; type=default; asset-type=script',
+    );
 
     const repl = new AssetJs(json);
     t.ok(repl.async);
@@ -349,7 +364,10 @@ tap.test('Js() - set "defer" - should construct object as t.equaled', (t) => {
         type: 'default',
     });
 
-    t.equal(obj.toHeader(), '</foo>; defer=true; type=default');
+    t.equal(
+        obj.toHeader(),
+        '</foo>; defer=true; type=default; asset-type=script',
+    );
 
     const repl = new AssetJs(json);
     t.ok(repl.defer);
@@ -372,7 +390,7 @@ tap.test('Js() - set "type" - should construct object as t.equaled', (t) => {
         type: 'esm',
     });
 
-    t.equal(obj.toHeader(), '</foo>; type=esm');
+    t.equal(obj.toHeader(), '</foo>; type=esm; asset-type=script');
 
     const repl = new AssetJs(json);
     t.equal(repl.type, 'esm');
@@ -411,7 +429,10 @@ tap.test('Js() - set "data" - should construct object as t.equaled', (t) => {
         type: 'default',
     });
 
-    t.equal(obj.toHeader(), '</foo>; type=default; data-foo=bar');
+    t.equal(
+        obj.toHeader(),
+        '</foo>; type=default; data-foo=bar; asset-type=script',
+    );
 
     const repl = new AssetJs(json);
     t.same(repl.data, [


### PR DESCRIPTION
In order to avoid trying to detect what sort of asset is being sent (using file extensions), its best that we explicitly send this information from the podlet to the layout since we have it.