### PR TITLE
Add hints support to incoming

### DIFF
--- a/lib/hints.js
+++ b/lib/hints.js
@@ -1,0 +1,43 @@
+import { EventEmitter } from 'node:events';
+
+export class Hints extends EventEmitter {
+    #expectedHints = new Set();
+    #receivedHints = new Set();
+
+    // pointless constructor with super to appease TS which cryptically errors otherwise.
+    constructor() {
+        super();
+    }
+
+    /**
+     * Adds a new expected hint to the set
+     * Expected hints are used to determine if all hints have been received
+     * @param {string} name - The name of the hint
+     */
+    addExpectedHint(name) {
+        this.#expectedHints.add(name);
+    }
+
+    /**
+     * Adds a new received hint to the set
+     * After each hint has been received, we check if all hints have been received
+     * and emit the 'hints-received' event if so
+     * @param {string} name - The name of the hint
+     */
+    addReceivedHint(name) {
+        this.#receivedHints.add(name);
+        if (this.allHintsReceived) {
+            this.emit('hints-received');
+        }
+    }
+
+    /**
+     * Value will be true if all expected hints have been received
+     */
+    get allHintsReceived() {
+        return (
+            this.#expectedHints.size === this.#receivedHints.size &&
+            [...this.#expectedHints].every((x) => this.#receivedHints.has(x))
+        );
+    }
+}

--- a/lib/hints.js
+++ b/lib/hints.js
@@ -21,13 +21,13 @@ export class Hints extends EventEmitter {
     /**
      * Adds a new received hint to the set
      * After each hint has been received, we check if all hints have been received
-     * and emit the 'hints-received' event if so
+     * and emit the 'complete' event if so
      * @param {string} name - The name of the hint
      */
     addReceivedHint(name) {
         this.#receivedHints.add(name);
         if (this.allHintsReceived) {
-            this.emit('hints-received');
+            this.emit('complete');
         }
     }
 

--- a/lib/http-incoming.js
+++ b/lib/http-incoming.js
@@ -1,4 +1,5 @@
 import { URL } from 'node:url';
+import { Hints } from './hints.js';
 
 const inspect = Symbol.for('nodejs.util.inspect.custom');
 
@@ -57,6 +58,9 @@ export default class HttpIncoming {
      * @type {Array<import('./asset-js.js').JavaScriptAsset | string>}
      */
     #js;
+
+    /** @type {Hints} */
+    hints = new Hints();
 
     /**
      * @constructor

--- a/package.json
+++ b/package.json
@@ -41,23 +41,23 @@
   },
   "devDependencies": {
     "@babel/eslint-parser": "7.25.1",
-    "@podium/schemas": "5.0.1",
+    "@podium/schemas": "5.0.6",
     "@semantic-release/changelog": "6.0.3",
     "@semantic-release/commit-analyzer": "13.0.0",
     "@semantic-release/git": "10.0.1",
-    "@semantic-release/github": "10.1.7",
+    "@semantic-release/github": "10.3.4",
     "@semantic-release/npm": "12.0.1",
     "@semantic-release/release-notes-generator": "14.0.1",
-    "@types/node": "20.16.2",
+    "@types/node": "22.5.5",
     "benchmark": "2.1.4",
-    "eslint": "9.9.1",
+    "eslint": "9.10.0",
     "eslint-config-prettier": "9.1.0",
     "eslint-plugin-prettier": "5.2.1",
     "globals": "15.9.0",
     "npm-run-all2": "5.0.2",
     "prettier": "3.3.3",
     "tap": "16.3.10",
-    "typescript": "5.5.4"
+    "typescript": "5.6.2"
   },
   "dependencies": {
     "camelcase": "8.0.0"

--- a/tests/asset-css.test.js
+++ b/tests/asset-css.test.js
@@ -477,7 +477,7 @@ tap.test('Css() - set "href" - should throw', (t) => {
 
 tap.test('Css() - validate object against schema - should validate', (t) => {
     const obj = new AssetCss({ value: '/foo' });
-    // @ts-ignore
+    // @ts-expect-error schema types not lining up, we should revisit
     t.notOk(schema.css([obj]).error);
     t.end();
 });

--- a/tests/asset-js.test.js
+++ b/tests/asset-js.test.js
@@ -455,7 +455,7 @@ tap.test('Js() - set "src"', (t) => {
 
 tap.test('Js() - validate object against schema - should validate', (t) => {
     const obj = new AssetJs({ value: '/foo' });
-    // @ts-ignore
+    // @ts-expect-error schema types not lining up, we should revisit
     t.notOk(schema.js([obj]).error);
     t.end();
 });

--- a/tests/hints.test.js
+++ b/tests/hints.test.js
@@ -1,0 +1,15 @@
+import tap from 'tap';
+import { Hints } from '../lib/hints.js';
+
+tap.test(
+    'PodiumHttpIncoming() - object tag - should be PodiumHttpIncoming',
+    (t) => {
+        const hints = new Hints();
+        hints.addExpectedHint('foo');
+        hints.addExpectedHint('bar');
+        hints.addReceivedHint('foo');
+        hints.addReceivedHint('bar');
+        t.equal(hints.allHintsReceived, true);
+        t.end();
+    },
+);

--- a/tests/http-incoming.test.js
+++ b/tests/http-incoming.test.js
@@ -370,7 +370,7 @@ tap.test('can read values from view with default types', (t) => {
     incoming.hints.addExpectedHint('foo');
     incoming.hints.addExpectedHint('bar');
 
-    incoming.hints.on('hints-received', () => {
+    incoming.hints.on('complete', () => {
         t.ok(incoming.hints.allHintsReceived);
         t.end();
     });

--- a/tests/http-incoming.test.js
+++ b/tests/http-incoming.test.js
@@ -358,3 +358,23 @@ tap.test('can read values from view with default types', (t) => {
     t.ok(incoming);
     t.end();
 });
+
+tap.test('can read values from view with default types', (t) => {
+    t.plan(1);
+    // really only here for tsc
+
+    /**
+     * @type {HttpIncoming}
+     */
+    const incoming = new HttpIncoming(SIMPLE_REQ, SIMPLE_RES);
+    incoming.hints.addExpectedHint('foo');
+    incoming.hints.addExpectedHint('bar');
+
+    incoming.hints.on('hints-received', () => {
+        t.ok(incoming.hints.allHintsReceived);
+        t.end();
+    });
+
+    incoming.hints.addReceivedHint('foo');
+    incoming.hints.addReceivedHint('bar');
+});


### PR DESCRIPTION
this PR adds a new hints property to HttpIncoming that can be used in the Podium client to track early hints as requests are sent and early hints are received back.

Eg. 

```js
...
incoming.hints.on('complete', () => {
  // all early hints have been received!
});
...

fetch(incoming, ...) {
  incoming.hints.addExpectedHint(this.name);
  // do the request
  request({
    onInfo() {
      incoming.hints.addReceivedHint(this.name);
    }
  });
}
```