### PR TITLE
fix: remove asset type header tagging

### DIFF
--- a/lib/asset-css.js
+++ b/lib/asset-css.js
@@ -228,7 +228,7 @@ export default class PodiumAssetCss {
         const attrs = Object.entries(this.toJSON())
             .filter(([key, value]) => value && key !== 'value')
             .map(([key, value]) => `${key}=${value}`);
-        return `<${this.#value}>; ${attrs.join('; ')}; asset-type=style`;
+        return `<${this.#value}>; ${attrs.join('; ')}`;
     }
 
     [inspect]() {

--- a/lib/asset-js.js
+++ b/lib/asset-js.js
@@ -246,7 +246,7 @@ export default class PodiumAssetJs {
                 }
                 return [`${key}=${value}`];
             });
-        return `<${this.#value}>; ${attrs.join('; ')}; asset-type=script`;
+        return `<${this.#value}>; ${attrs.join('; ')}`;
     }
 
     [inspect]() {

--- a/tests/asset-css.test.js
+++ b/tests/asset-css.test.js
@@ -236,7 +236,7 @@ tap.test(
 
         t.equal(
             obj.toHeader(),
-            '</foo>; crossorigin=bar; type=text/css; rel=stylesheet; asset-type=style',
+            '</foo>; crossorigin=bar; type=text/css; rel=stylesheet',
         );
 
         const repl = new AssetCss(json);
@@ -270,7 +270,7 @@ tap.test(
 
         t.equal(
             obj.toHeader(),
-            '</foo>; disabled=true; type=text/css; rel=stylesheet; asset-type=style',
+            '</foo>; disabled=true; type=text/css; rel=stylesheet',
         );
 
         const repl = new AssetCss(json);
@@ -304,7 +304,7 @@ tap.test(
 
         t.equal(
             obj.toHeader(),
-            '</foo>; hreflang=bar; type=text/css; rel=stylesheet; asset-type=style',
+            '</foo>; hreflang=bar; type=text/css; rel=stylesheet',
         );
 
         const repl = new AssetCss(json);
@@ -334,10 +334,7 @@ tap.test('Css() - set "title" - should construct object as expected', (t) => {
         rel: 'stylesheet',
     });
 
-    t.equal(
-        obj.toHeader(),
-        '</foo>; title=bar; type=text/css; rel=stylesheet; asset-type=style',
-    );
+    t.equal(obj.toHeader(), '</foo>; title=bar; type=text/css; rel=stylesheet');
 
     const repl = new AssetCss(json);
     t.equal(repl.title, 'bar');
@@ -365,10 +362,7 @@ tap.test('Css() - set "media" - should construct object as expected', (t) => {
         rel: 'stylesheet',
     });
 
-    t.equal(
-        obj.toHeader(),
-        '</foo>; media=bar; type=text/css; rel=stylesheet; asset-type=style',
-    );
+    t.equal(obj.toHeader(), '</foo>; media=bar; type=text/css; rel=stylesheet');
 
     const repl = new AssetCss(json);
     t.equal(repl.media, 'bar');
@@ -392,10 +386,7 @@ tap.test('Css() - set "type" - should construct object as expected', (t) => {
         rel: 'stylesheet',
     });
 
-    t.equal(
-        obj.toHeader(),
-        '</foo>; type=bar; rel=stylesheet; asset-type=style',
-    );
+    t.equal(obj.toHeader(), '</foo>; type=bar; rel=stylesheet');
 
     const repl = new AssetCss(json);
     t.equal(repl.type, 'bar');
@@ -419,7 +410,7 @@ tap.test('Css() - set "rel" - should construct object as expected', (t) => {
         rel: 'bar',
     });
 
-    t.equal(obj.toHeader(), '</foo>; type=text/css; rel=bar; asset-type=style');
+    t.equal(obj.toHeader(), '</foo>; type=text/css; rel=bar');
 
     const repl = new AssetCss(json);
     t.equal(repl.rel, 'bar');
@@ -447,10 +438,7 @@ tap.test('Css() - set "as" - should construct object as expected', (t) => {
         rel: 'stylesheet',
     });
 
-    t.equal(
-        obj.toHeader(),
-        '</foo>; type=text/css; rel=stylesheet; as=bar; asset-type=style',
-    );
+    t.equal(obj.toHeader(), '</foo>; type=text/css; rel=stylesheet; as=bar');
 
     const repl = new AssetCss(json);
     t.equal(repl.as, 'bar');
@@ -489,6 +477,7 @@ tap.test('Css() - set "href" - should throw', (t) => {
 
 tap.test('Css() - validate object against schema - should validate', (t) => {
     const obj = new AssetCss({ value: '/foo' });
+    // @ts-ignore
     t.notOk(schema.css([obj]).error);
     t.end();
 });

--- a/tests/asset-js.test.js
+++ b/tests/asset-js.test.js
@@ -219,10 +219,7 @@ tap.test(
             type: 'default',
         });
 
-        t.equal(
-            obj.toHeader(),
-            '</foo>; referrerpolicy=bar; type=default; asset-type=script',
-        );
+        t.equal(obj.toHeader(), '</foo>; referrerpolicy=bar; type=default');
 
         const repl = new AssetJs(json);
         t.equal(repl.referrerpolicy, 'bar');
@@ -249,10 +246,7 @@ tap.test(
             type: 'default',
         });
 
-        t.equal(
-            obj.toHeader(),
-            '</foo>; crossorigin=bar; type=default; asset-type=script',
-        );
+        t.equal(obj.toHeader(), '</foo>; crossorigin=bar; type=default');
 
         const repl = new AssetJs(json);
         t.equal(repl.crossorigin, 'bar');
@@ -279,10 +273,7 @@ tap.test(
             type: 'default',
         });
 
-        t.equal(
-            obj.toHeader(),
-            '</foo>; integrity=bar; type=default; asset-type=script',
-        );
+        t.equal(obj.toHeader(), '</foo>; integrity=bar; type=default');
 
         const repl = new AssetJs(json);
         t.equal(repl.integrity, 'bar');
@@ -309,10 +300,7 @@ tap.test(
             type: 'default',
         });
 
-        t.equal(
-            obj.toHeader(),
-            '</foo>; nomodule=true; type=default; asset-type=script',
-        );
+        t.equal(obj.toHeader(), '</foo>; nomodule=true; type=default');
 
         const repl = new AssetJs(json);
         t.ok(repl.nomodule);
@@ -337,10 +325,7 @@ tap.test('Js() - set "async" - should construct object as t.equaled', (t) => {
         type: 'default',
     });
 
-    t.equal(
-        obj.toHeader(),
-        '</foo>; async=true; type=default; asset-type=script',
-    );
+    t.equal(obj.toHeader(), '</foo>; async=true; type=default');
 
     const repl = new AssetJs(json);
     t.ok(repl.async);
@@ -364,10 +349,7 @@ tap.test('Js() - set "defer" - should construct object as t.equaled', (t) => {
         type: 'default',
     });
 
-    t.equal(
-        obj.toHeader(),
-        '</foo>; defer=true; type=default; asset-type=script',
-    );
+    t.equal(obj.toHeader(), '</foo>; defer=true; type=default');
 
     const repl = new AssetJs(json);
     t.ok(repl.defer);
@@ -390,7 +372,7 @@ tap.test('Js() - set "type" - should construct object as t.equaled', (t) => {
         type: 'esm',
     });
 
-    t.equal(obj.toHeader(), '</foo>; type=esm; asset-type=script');
+    t.equal(obj.toHeader(), '</foo>; type=esm');
 
     const repl = new AssetJs(json);
     t.equal(repl.type, 'esm');
@@ -429,10 +411,7 @@ tap.test('Js() - set "data" - should construct object as t.equaled', (t) => {
         type: 'default',
     });
 
-    t.equal(
-        obj.toHeader(),
-        '</foo>; type=default; data-foo=bar; asset-type=script',
-    );
+    t.equal(obj.toHeader(), '</foo>; type=default; data-foo=bar');
 
     const repl = new AssetJs(json);
     t.same(repl.data, [
@@ -476,6 +455,7 @@ tap.test('Js() - set "src"', (t) => {
 
 tap.test('Js() - validate object against schema - should validate', (t) => {
     const obj = new AssetJs({ value: '/foo' });
+    // @ts-ignore
     t.notOk(schema.js([obj]).error);
     t.end();
 });


### PR DESCRIPTION
Moving this tag handling to the podlet and the layout so that toHeader is still useful in situations where the asset-type tagging is not needed. Eg. from the client to the browser when generating preload headers.