### PR TITLE
test: add failing unit test for structuredClone

### DIFF
--- a/tests/asset-css.test.js
+++ b/tests/asset-css.test.js
@@ -481,3 +481,21 @@ tap.test('Css() - validate object against schema - should validate', (t) => {
     t.notOk(schema.css([obj]).error);
     t.end();
 });
+
+tap.test('Css() - works with structuredClone', (t) => {
+    const original = new AssetCss({ value: '/foo', scope: 'shadow-dom' });
+    const clone = structuredClone(original);
+
+    t.notEqual(
+        clone,
+        original,
+        'Expected structuredClone to produce a different instance',
+    );
+
+    t.equal(typeof original, 'object');
+
+    t.equal(clone.value, original.value);
+    t.equal(clone.scope, original.scope);
+
+    t.end();
+});

--- a/tests/asset-js.test.js
+++ b/tests/asset-js.test.js
@@ -470,3 +470,22 @@ tap.test('Js() - ignores async if both id and defer are set', (t) => {
     t.notOk(asset.async, 'Async should be ignored if defer is set');
     t.end();
 });
+
+tap.test('Js() - works with structuredClone', (t) => {
+    const original = new AssetJs({ value: '/foo', async: true });
+    const clone = structuredClone(original);
+
+    t.notEqual(
+        clone,
+        original,
+        'Expected structuredClone to produce a different instance',
+    );
+
+    t.equal(typeof original, 'object');
+
+    t.equal(clone.value, original.value);
+    t.equal(clone.async, original.async);
+
+    t.end();
+});
+


### PR DESCRIPTION
Demonstrating an issue that blocks us from adopting the native `structuredClone` as a replacement for `lodash.clonedeep` in [client](https://github.com/podium-lib/client/blob/79a58e9e4aa600d8dd4183536f00f0dfcacb5035/lib/resolver.cache.js#L39).

I think `cloneDeep` only works because it doesn't actualy clone the asset class instances.

https://github.com/lodash/lodash/blob/ddfd9b11a0126db2302cb70ec9973b66baec0975/lodash.js#L2657

We hit this branch where it is an object, but not a clonable one, so it "clones" by returning the same instance. Confirmed with console log.

```
console.log(outgoing.manifest.css[0] === cached.css[0]);
```

This on the line after cloning prints `true` across all unit tests in client.